### PR TITLE
Allow environment variables for exportarr

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: 'v2'
 name: 'media-servarr-base'
 description: 'Base chart for media-servarr charts'
 type: 'application'
-version: 0.2.3
+version: 0.2.4
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -7,12 +7,12 @@ keywords:
   - 'homarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.2.3
+version: 0.2.4
 appVersion: '0.14.4'
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.2.3
+    version: 0.2.4
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/homarr/values.yaml
+++ b/charts/homarr/values.yaml
@@ -45,13 +45,6 @@ persistentVolumeClaims:
     requestStorage: '1Gi'
     selector: {}
 
-service:
-  type: 'ClusterIP'
-  ports:
-    - targetPort: 'http'
-      protocol: 'TCP'
-      name: 'http'
-
 ingress:
   enabled: true
   path: '/'

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -11,12 +11,12 @@ keywords:
   - 'lidarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.2.1
+version: 0.2.2
 appVersion: '2.0.7'
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.2.2
+    version: 0.2.4
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/lidarr/README.md
+++ b/charts/lidarr/README.md
@@ -139,6 +139,7 @@ Enabling metrics enables a sidecar container being attached for [exportarr](http
 ```yaml
 metrics:
   enabled: true
+  env: []
 ```
 
 It is recommended to install [kube-prometheus chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first for the CRD to be supported. It is not included as a dependency by default in this package!

--- a/charts/lidarr/values.yaml
+++ b/charts/lidarr/values.yaml
@@ -80,13 +80,6 @@ persistentVolumeClaims:
     requestStorage: '1Gi'
     selector: {}
 
-service:
-  type: 'ClusterIP'
-  ports:
-    - targetPort: 'http'
-      protocol: 'TCP'
-      name: 'http'
-
 ingress:
   enabled: true
 

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'prowlarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.2.1
+version: 0.2.2
 appVersion: '1.12.2'
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.2.2
+    version: 0.2.4
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/prowlarr/README.md
+++ b/charts/prowlarr/README.md
@@ -134,6 +134,11 @@ Enabling metrics enables a sidecar container being attached for [exportarr](http
 ```yaml
 metrics:
   enabled: true
+  env:
+    - name: 'PROWLARR__BACKFILL'
+      value: 'true'
+    - name: 'PROWLARR__BACKFILL_SINCE_DATE'
+      value: '1970-01-01'
 ```
 
 It is recommended to install [kube-prometheus chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first for the CRD to be supported. It is not included as a dependency by default in this package!

--- a/charts/prowlarr/values.yaml
+++ b/charts/prowlarr/values.yaml
@@ -76,7 +76,7 @@ ingress:
   enabled: true
 
 metrics:
-  enabled: true
+  enabled: false
   app: 'prowlarr'
   port:
     number: 9703

--- a/charts/prowlarr/values.yaml
+++ b/charts/prowlarr/values.yaml
@@ -87,3 +87,6 @@ metrics:
   app: 'prowlarr'
   port:
     number: 9703
+  env:
+    # - name: 'PROWLARR__BACKFILL'
+    #   value: 'true'

--- a/charts/prowlarr/values.yaml
+++ b/charts/prowlarr/values.yaml
@@ -72,13 +72,6 @@ persistentVolumeClaims:
     requestStorage: '1Gi'
     selector: {}
 
-service:
-  type: 'ClusterIP'
-  ports:
-    - targetPort: 'http'
-      protocol: 'TCP'
-      name: 'http'
-
 ingress:
   enabled: true
 

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'radarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.2.2
+version: 0.2.3
 appVersion: '5.2.6'
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.2.2
+    version: 0.2.4
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/radarr/README.md
+++ b/charts/radarr/README.md
@@ -136,6 +136,7 @@ Enabling metrics enables a sidecar container being attached for [exportarr](http
 ```yaml
 metrics:
   enabled: true
+  env: []
 ```
 
 It is recommended to install [kube-prometheus chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first for the CRD to be supported. It is not included as a dependency by default in this package!

--- a/charts/radarr/values.yaml
+++ b/charts/radarr/values.yaml
@@ -80,13 +80,6 @@ persistentVolumeClaims:
     requestStorage: '1Gi'
     selector: {}
 
-service:
-  type: 'ClusterIP'
-  ports:
-    - targetPort: 'http'
-      protocol: 'TCP'
-      name: 'http'
-
 ingress:
   enabled: true
 

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'readarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.2.1
+version: 0.2.2
 appVersion: '0.3.17-develop'
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.2.2
+    version: 0.2.4
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/readarr/README.md
+++ b/charts/readarr/README.md
@@ -136,6 +136,7 @@ Enabling metrics enables a sidecar container being attached for [exportarr](http
 ```yaml
 metrics:
   enabled: true
+  env: []
 ```
 
 It is recommended to install [kube-prometheus chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first for the CRD to be supported. It is not included as a dependency by default in this package!

--- a/charts/readarr/values.yaml
+++ b/charts/readarr/values.yaml
@@ -80,18 +80,11 @@ persistentVolumeClaims:
     requestStorage: '1Gi'
     selector: {}
 
-service:
-  type: 'ClusterIP'
-  ports:
-    - targetPort: 'http'
-      protocol: 'TCP'
-      name: 'http'
-
 ingress:
   enabled: true
 
 metrics:
-  enabled: true
+  enabled: false
   app: 'readarr'
   port:
     number: 9705

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'sonarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.2.1
+version: 0.2.2
 appVersion: '4.0.1'
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.2.2
+    version: 0.2.4
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sonarr/README.md
+++ b/charts/sonarr/README.md
@@ -136,6 +136,7 @@ Enabling metrics enables a sidecar container being attached for [exportarr](http
 ```yaml
 metrics:
   enabled: true
+  env: []
 ```
 
 It is recommended to install [kube-prometheus chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first for the CRD to be supported. It is not included as a dependency by default in this package!

--- a/charts/sonarr/values.yaml
+++ b/charts/sonarr/values.yaml
@@ -80,18 +80,11 @@ persistentVolumeClaims:
     requestStorage: '1Gi'
     selector: {}
 
-service:
-  type: 'ClusterIP'
-  ports:
-    - targetPort: 'http'
-      protocol: 'TCP'
-      name: 'http'
-
 ingress:
   enabled: true
 
 metrics:
-  enabled: true
+  enabled: false
   app: 'sonarr'
   port:
     number: 9706

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -113,6 +113,9 @@ spec:
                 secretKeyRef:
                   name: '{{ include "media-servarr-base.fullname" . }}'
                   key: 'apiKey'
+            {{- if .Values.metrics.env }}
+            {{ toYaml .Values.metrics.env | nindent 12 }}
+            {{- end }}
           ports:
             - name: '{{ .Values.metrics.port.name }}'
               containerPort: {{ .Values.metrics.port.number }}

--- a/values.yaml
+++ b/values.yaml
@@ -143,6 +143,7 @@ metrics:
     repository: 'ghcr.io/onedr0p/exportarr'
     tag: 'v1.6.1'
     pullPolicy: 'IfNotPresent'
+  env:
   port:
     name: 'monitoring'
   resources:


### PR DESCRIPTION
## Description

Allow for PROWLARR__BACKFILL - and then by default enable any exportarr environment variable for config.

Also, disable some metrics by default which shouldn't have been enabled by default!

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [x] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [x] My changes are tested and proven to work.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.