### PR TITLE
Add information about IsStartupWizardCompleted to fix security issue

### DIFF
--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -55,6 +55,8 @@ application:
     - filename: 'system.xml'
       contents: |
         # We could add <EnableMetrics>true</EnableMetrics> to enable prometheus metrics
+        # It is recommended to add <IsStartupWizardCompleted>true</IsStartupWizardCompleted> to
+        #  prevent the wizard running again after initial setup.
         ...
       mountPath: '/config/config/system.xml'
     - filename: 'encoding.xml'
@@ -79,7 +81,7 @@ The following volumes are available by default:
 - **ebooks** - Location of ebooks
 - **film** - Location of movies
 - **music** - Location of music
-- **telivion** - Location of TV shows
+- **television** - Location of TV shows
 
 ```yaml
 deployment:
@@ -92,7 +94,9 @@ deployment:
       nfs:
         server: 'fileserver.local'
         path: '/srv/media/ebooks/'
-    
+    film:
+    music:
+    television:
 ```
 
 By default, a PersistentVolumeClaim will be provisioned for the `config`, but `emptyDir: {}` will be used for downloads and film - but it is recommended enable some type of PVC and PV!
@@ -126,17 +130,9 @@ ingress:
 
 ### Metrics
 
-Enabling metrics enables a sidecar container being attached for [exportarr](https://github.com/onedr0p/exportarr/) - and a ServiceMonitor CRD to be consumed by the [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) package.
+Prometheus metrics are enabled by placing `<EnableMetrics>true</EnableMetrics>` in System.xml.
 
-```yaml
-metrics:
-  enabled: true
-  env: []
-```
-
-It is recommended to install [kube-prometheus chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first for the CRD to be supported. It is not included as a dependency by default in this package!
-
-Unless changed with `metrics.port.number` you can then consume metrics over port `9702`.
+Read more about this functionality in the [official documentation](https://jellyfin.org/docs/general/networking/monitoring/)
 
 ### Advanced
 

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -25,16 +25,18 @@ application:
         </NetworkConfiguration>
       mountPath: '/config/config/network.xml'
     # System Options
-    - filename: 'system.xml'
-      contents: |
-        <?xml version="1.0" encoding="utf-8"?>
-        <ServerConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-          <EnableMetrics>true</EnableMetrics>
-          <PreferredMetadataLanguage>en</PreferredMetadataLanguage>
-          <MetadataCountryCode>GB</MetadataCountryCode>
-          <UICulture>en-GB</UICulture>
-        </ServerConfiguration>
-      mountPath: '/config/config/system.xml'
+    # - filename: 'system.xml'
+    #   contents: |
+    #     <?xml version="1.0" encoding="utf-8"?>
+    #     <ServerConfiguration xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    #       <EnableMetrics>true</EnableMetrics>
+    #       <PreferredMetadataLanguage>en</PreferredMetadataLanguage>
+    #       <MetadataCountryCode>GB</MetadataCountryCode>
+    #       <UICulture>en-GB</UICulture>
+    #       <!-- Change me to false to run the setup wizard, but make sure you keep it true!! -->
+    #       <IsStartupWizardCompleted>true</IsStartupWizardCompleted>
+    #     </ServerConfiguration>
+    #   mountPath: '/config/config/system.xml'
 
 #
 # Resource - DEPLOYMENT


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the Helm chart collection
---

## Description

`<IsStartupWizardCompleted />` would always be set to `false` after jellyfin started or restarted.

This was due to the `system.xml` configmap not including this value, so jellyfin would default it. However, this poses not only an annoyance but a security risk (as anybody could recreate through an admin account).

By adding a default value in the configmap we will have to make assumptions on the persisted state of jellyfin. Therefore, this configmap has been disabled by default and the README updated to reflect the default recommended configmap and this value and what to set it to.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- ~I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.~
- [x] My changes are tested and proven to work.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
