### PR TITLE
Pull secrets and service account templating fix

### DIFF
--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - 'prowlarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.7.1
-appVersion: '1.30.2'
+version: 0.7.0
+appVersion: '1.24.3'
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - 'prowlarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.7.0
-appVersion: '1.24.3'
+version: 0.7.1
+appVersion: '1.30.2'
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -5,7 +5,7 @@
 apiVersion: 'v1'
 kind: 'ServiceAccount'
 metadata:
-  name: {{ include "media-servarr-base.serviceAccount.name" . }}
+  name: {{ include "media-servarr-base.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "media-servarr-base.labels" . | nindent 4 }}

--- a/templates/serviceaccount.yaml
+++ b/templates/serviceaccount.yaml
@@ -13,6 +13,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+imagePullSecrets:
+  {{- range .Values.serviceAccount.imagePullSecrets }}
+  - name: '{{ .name }}'
+  {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -119,6 +119,8 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: 'default'
+  # imagePullSecrets for private repositories.
+  imagePullSecrets: {}
 
 service:
   type: 'ClusterIP'


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request to contribute to the Helm chart collection
---

## Description
- fixed templating for the serviceaccount
- added possibility to attach pull-secrets to a serviceaccount

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [ ] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [ ] My changes are tested and proven to work.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Testing

I already use it in my deployment.

## Additional Information

I skipped the Chart version updates so you can update at your pace.