### PR TITLE
Update default Readarr auth to External

### DIFF
--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - 'readarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.8.0
+version: 0.8.1
 appVersion: '0.4.0-develop'
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png'
 dependencies:

--- a/charts/readarr/values.yaml
+++ b/charts/readarr/values.yaml
@@ -31,7 +31,7 @@ application:
         <BindAddress>*</BindAddress>
         <ApiKey>$apiKey</ApiKey>
         <AnalyticsEnabled>False</AnalyticsEnabled>
-        <AuthenticationMethod>None</AuthenticationMethod>
+        <AuthenticationMethod>External</AuthenticationMethod>
         <UpdateMechanism>Docker</UpdateMechanism>
         <Branch>develop</Branch>
         <InstanceName>Readarr</InstanceName>


### PR DESCRIPTION


## Description

As it is in radarr, sonarr. This is managing a previous version update that bought auth back in line with these.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [ ] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [x] My changes are tested and proven to work.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

