### PR TITLE
Fix/support strip prefix for appversion

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -20,14 +20,14 @@ jobs:
             repo: 'linuxserver/docker-bazarr'
           - name: 'flaresolverr'
             repo: 'FlareSolverr/FlareSolverr'
-          # Homarr release numbers are prefixed with v, but the package is not.
-          # To come up with a simple solution, like stripVersionPrefx: 'v'
-          # - name: 'homarr'
-          #   repo: 'ajnart/homarr'
+          - name: 'homarr'
+            repo: 'ajnart/homarr'
+            strip_prefix: 'v'
           - name: 'jellyfin'
             repo: 'jellyfin/jellyfin'
           - name: 'jellyseerr'
             repo: 'Fallenbagel/jellyseerr'
+            strip_prefix: 'v'
           - name: 'lidarr'
             repo: 'linuxserver/docker-lidarr'
           - name: 'prowlarr'
@@ -50,10 +50,14 @@ jobs:
 
       - name: 'Update AppVersion and ChartVersion'
         run: |
+          # Set global script settings
+          export ALLOW_PRERELEASE='${{ matrix.allow_prerelease }}'
+          export STRIP_VERSION_PREFIX='${{ matrix.strip_prefix }}'
+
+          # Call main script to fetch newest app version
           ./scripts/update_appversion.sh \
             '${{ matrix.name }}' \
-            '${{ matrix.repo }}' \
-            '${{ matrix.allow_prerelease }}'
+            '${{ matrix.repo }}'
 
       - name: 'Check for changes'
         id: changes

--- a/scripts/update_appversion.sh
+++ b/scripts/update_appversion.sh
@@ -120,17 +120,17 @@ update_chartversion() {
 # and Chart version if needed.
 #
 # Globals:
-#   REPO_DIR (read-only): The base directory for the repository.
+#   REPO_DIR: The base directory for the repository.
+#   ALLOW_PRERELEASE: A boolean string ("true" or "false") indicating whether to allow prerelease versions (default: false).
 # Arguments:
 #   name: The name of the chart (folder under charts/).
 #   repo: The GitHub repository in the form "owner/repo".
-#   allow_prerelease: A boolean string ("true" or "false") indicating whether to allow prerelease versions (default: false).
 # Outputs:
 #   Writes changes to Chart.yaml files and logs actions to stdout.
 main() {
   local name="$1"
   local repo="$2"
-  local allow_prerelease="${3:-false}"
+  local allow_prerelease="${ALLOW_PRERELEASE:-false}"
   local chart_file="${REPO_DIR}/charts/${name}/Chart.yaml"
   local latest_version
   local current_version


### PR DESCRIPTION
Add strip prefix for app version -

some release versions (homarr, jellyfin) are prefixed with 'v', but their packages aren't. This supports adding wildcards to stirp them