### PR TITLE
Make "update_base.sh" non-FHS compliant

### DIFF
--- a/scripts/update_base.sh
+++ b/scripts/update_base.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script automates the process of incrementing version numbers in Helm Chart.yaml files and updating specific dependencies.
 # It supports major, minor, or patch version increments and updates dependencies to match the root Chart.yaml version.


### PR DESCRIPTION
## Description

As "update_appversion.sh" does it already, by switching from `#!/bin/bash` to `#!/usr/bin/env bash` the script will also be usable by non-FHS compliant systems like NixOS (which I am using btw)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

My changes do not impact any charts.

## Testing

Run it on my system and updating versions works like before. Please run it once on your side so we can be sure everything is working.

