### PR TITLE
Use github default branch variable as pull-request base

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -92,4 +92,4 @@ jobs:
           title: "⭐️ New App Version: Update ${{ matrix.name }}"
           body: 'Automated Workflow. New App Version found for Chart'
           branch: ${{ env.BRANCH_NAME }}
-          base: 'main'
+          base: ${{ github.event.repository.default_branch }}


### PR DESCRIPTION
## Description

Instead of the hardcoded branch name use the repository default branch name for the pull-request action

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

