### PR TITLE
Only use Semver compatible releases

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -17,33 +17,34 @@ jobs:
       matrix:
         include:
           - name: 'bazarr'
-            repo: 'linuxserver/docker-bazarr'
+            repo: 'linuxserver/bazarr'
           - name: 'flaresolverr'
-            repo: 'FlareSolverr/FlareSolverr'
+            repo: 'flaresolverr/flaresolverr'
           - name: 'homarr'
             repo: 'ajnart/homarr'
+            hub: 'ghcr'
             strip_prefix: 'v'
           - name: 'jellyfin'
             repo: 'jellyfin/jellyfin'
             strip_prefix: 'v'
           - name: 'jellyseerr'
-            repo: 'Fallenbagel/jellyseerr'
+            repo: 'fallenbagel/jellyseerr'
             strip_prefix: 'v'
           - name: 'lidarr'
-            repo: 'linuxserver/docker-lidarr'
+            repo: 'linuxserver/lidarr'
           - name: 'prowlarr'
-            repo: 'linuxserver/docker-prowlarr'
+            repo: 'linuxserver/prowlarr'
           - name: 'radarr'
-            repo: 'linuxserver/docker-radarr'
+            repo: 'linuxserver/radarr'
           - name: 'readarr'
-            repo: 'linuxserver/docker-readarr'
+            repo: 'linuxserver/readarr'
             allow_prerelease: true
           - name: 'sabnzbd'
-            repo: 'linuxserver/docker-sabnzbd'
+            repo: 'linuxserver/sabnzbd'
           - name: 'sonarr'
-            repo: 'linuxserver/docker-sonarr'
+            repo: 'linuxserver/sonarr'
           - name: 'transmission'
-            repo: 'linuxserver/docker-transmission'
+            repo: 'linuxserver/transmission'
     steps:
       - uses: 'actions/checkout@v4'
         with:
@@ -58,7 +59,8 @@ jobs:
           # Call main script to fetch newest app version
           ./scripts/update_appversion.sh \
             '${{ matrix.name }}' \
-            '${{ matrix.repo }}'
+            '${{ matrix.repo }}' \
+            '${{ matrix.hub }}'
 
       - name: 'Check for changes'
         id: changes


### PR DESCRIPTION
## Description

Closes #189 

For matching for latest versions it was easier to differ between dockerhub/ghcr.io then only using the github API.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [x] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [x] My changes are tested and proven to work.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Testing

I tested it in a Github Action on my branch and the output seemed reasonable, also the detection if a tag is already there does still work.

```bash
Release 'v3.3.21' found for 'flaresolverr/flaresolverr'
Chart is already up to date
```

## Additional Information

Disclaimer: I used ChatGPT for this mundane work, if this is a problem for you please close the PR.
