### PR TITLE
fix, Set default strategy of an deployment to "Recreate"

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -18,7 +18,7 @@ spec:
     matchLabels:
       {{- include "media-servarr-base.selectorLabels" . | nindent 6 }}
   strategy:
-    {{- with .Values.deployment.strategy }}
+    {{- with (default (dict "type" "Recreate") .Values.deployment.strategy) }}
       {{- toYaml . | nindent 6 }}
     {{- end }}
   template:


### PR DESCRIPTION
## Description

Because the default mode for PVCs is "ReadWriteOnce" the deployment strategy needs to be "Recreate" so that PVCs can be rebound without "multi attach" errors.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Additional Information

I did not update the base chart version because I am not sure if you want to merge additional PRs
