### PR TITLE
feat: allow initContainers for all charts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: 'v2'
 name: 'media-servarr-base'
 description: 'Base chart for media-servarr charts'
 type: 'application'
-version: 0.8.0
+version: 0.9.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'bazarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.8.2
+version: 0.8.3
 appVersion: 1.5.2
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/flaresolverr/Chart.yaml
+++ b/charts/flaresolverr/Chart.yaml
@@ -9,12 +9,12 @@ keywords:
   - 'bypass'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.7.2
+version: 0.7.3
 appVersion: v3.3.25
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/flaresolverr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -7,12 +7,12 @@ keywords:
   - 'homarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.8.1
+version: 0.8.2
 appVersion: 0.15.10
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/homarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -15,12 +15,12 @@ keywords:
   - 'jellyfin'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.7.1
+version: 0.7.2
 appVersion: 10.10.7
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -11,12 +11,12 @@ keywords:
   - 'lidarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.13.2
+version: 0.13.3
 appVersion: 2.12.4
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'prowlarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.0
+version: 0.15.1
 appVersion: 1.37.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'radarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.17.0
+version: 0.17.1
 appVersion: 5.26.2
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'readarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.9.1
+version: 0.9.2
 appVersion: 0.4.19-nightly
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -8,12 +8,12 @@ keywords:
   - 'sabnzbd'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.6.3
+version: 0.6.4
 appVersion: 4.5.2
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'sonarr'
 kubeversion: ">=1.24.0-0"
 type: 'application'
-version: 0.8.3
+version: 0.8.4
 appVersion: 4.0.15
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'usenet'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.8.2
+version: 0.8.3
 appVersion: 4.0.6
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/transmission/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.8.0
+    version: 0.9.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -41,9 +41,9 @@ spec:
         If application.config includes valus, we'll use an init container to also set secrets, if
           applicable, and add to a temporary rw storage (as servarr apps often crash if these files are ro
         */}}
-      {{- if $config }}
-      {{/* Add config as array if not already */}}
+      {{- if or $config .Values.deployment.initContainers }}
       initContainers:
+        {{- if $config }}
         - name: 'prepare-config'
           image: 'alpine'
           volumeMounts:
@@ -83,6 +83,10 @@ spec:
                 '/config-processed/{{ .filename }}'
               {{- end }}
               {{- end }}
+        {{- end }}
+        {{- with .Values.deployment.initContainers }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         {{- with .Values.deployment.sideCarContainers }}

--- a/values.yaml
+++ b/values.yaml
@@ -98,6 +98,14 @@ deployment:
   #   for example, running a vpn container such as qdm12/gluetun for network traffic
   sideCarContainers: []
 
+  initContainers: []
+    # - name: 'init-myservice'
+    #   image: 'busybox'
+    #   command: ['sh', '-c', 'echo Hello from the init container!']
+    #   volumeMounts:
+    #     - name: 'init-volume'
+    #       mountPath: '/data'
+
   volumes: {}
     # config:
     #   persistentVolumeClaim:


### PR DESCRIPTION
## Description

I noticed it not possible to add initContainers, but I need that possibility, so I added it and bumped all chart versions so the others have that too. Thanks for reviewing!

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [X] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [X] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [X] My changes are tested and proven to work.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce the testing. Also, list any relevant details for your test configuration.

- helm template and diff with different scenarios (initContainer added, not added)
- deployed radarr

