### PR TITLE
Add support for runtimeclassname

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: 'v2'
 name: 'media-servarr-base'
 description: 'Base chart for media-servarr charts'
 type: 'application'
-version: 0.9.0
+version: 0.10.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -20,7 +20,7 @@ appVersion: 10.10.7
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.9.0
+    version: 0.10.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/jellyfin/values.yaml
+++ b/charts/jellyfin/values.yaml
@@ -43,9 +43,23 @@ application:
 # This is to set up and define the application deployment
 #
 deployment:
+
+# For Nvidia transcoding support
+  # nodeSelector:
+  #   nvidia.com/gpu.present: "true"
+
+  # runtimeClassName: "nvidia"
+
   container:
     image:
       repository: 'jellyfin/jellyfin'
+
+    # For Nvidia transcoding support
+    # env:
+    #   - name: 'NVIDIA_VISIBLE_DEVICES'
+    #     value: 'all'
+    #   - name: 'NVIDIA_DRIVER_CAPABILITIES'
+    #     value: 'all'
 
     # Additional volumeMounts on the output Deployment definition.
     volumeMounts:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -88,8 +88,8 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.deployment.runtimeClass }}
-      runtimeClass: {{ .Values.deployment.runtimeClass }}
+      {{- if .Values.deployment.runtimeClassName }}
+      runtimeClassName: {{ .Values.deployment.runtimeClassName }}
       {{- end }}
       containers:
         {{- with .Values.deployment.sideCarContainers }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -88,6 +88,9 @@ spec:
           {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- end }}
+      {{- if .Values.deployment.runtimeClass }}
+      runtimeClass: {{ .Values.deployment.runtimeClass }}
+      {{- end }}
       containers:
         {{- with .Values.deployment.sideCarContainers }}
           {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
## Description

Please provide a summary of your changes and the chart name and version they pertain to. Include the motivation behind these changes and what issue(s) this PR addresses, if applicable.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x ] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ x ] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [ x ] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [ x ] My changes are tested and proven to work.
- [ x ] I have performed a self-review of my own code.
- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] I have made corresponding changes to the documentation.
- [ x ] My changes generate no new warnings.

## Testing

Please describe the tests that you ran to verify your changes. Provide instructions so reviewers can reproduce the testing. Also, list any relevant details for your test configuration.

- Deployed my branch in production and verified it is deploying with the correct runtimeclass and leveraging the GPU for transcoding.

## Additional Information

Bumped the central chart version and the dependency version in the Jellyfin chart. Did not bump any other chart versions; not sure what your preference would be. I don't know if any other chart can actually leverage this addition, but I also didn't see another way to add this that wasn't potentially higher maintenance.
