### PR TITLE
Align tinyMediaManager media mount paths

### DIFF
--- a/charts/tinymediamanager/Chart.yaml
+++ b/charts/tinymediamanager/Chart.yaml
@@ -8,9 +8,9 @@ keywords:
   - 'movies'
   - 'tv'
   - 'tinymediamanager'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.1.4
+version: 1.0.0
 appVersion: 5.2.12
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'
 maintainers:

--- a/charts/tinymediamanager/values.yaml
+++ b/charts/tinymediamanager/values.yaml
@@ -42,9 +42,9 @@ deployment:
       - name: 'data'
         mountPath: '/data'
       - name: 'film'
-        mountPath: '/media/movies'
+        mountPath: '/film'
       - name: 'television'
-        mountPath: '/media/tvshows'
+        mountPath: '/tv'
 
   volumes:
     data:


### PR DESCRIPTION
## Description

Throughout this repo, mount paths are /film + /television by default.

This just aligns tinymediamanager defaults as the same to prevent confusion and to prioritise standardisation across these charts.

This could break file mappings for existing installations that rely on the old paths.

Adding the following in your personal values.yaml file will restore the existing mappings:

```
deployment:
  container:
    # Additional volumeMounts on the output Deployment definition.
    volumeMounts:
      - name: 'data'
        mountPath: '/data'
      - name: 'film'
        mountPath: '/media/movies'
      - name: 'television'
        mountPath: '/media/tvshows'
```

**major version to be released because of this**

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [ ] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [ ] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [x] My changes are tested and proven to work.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
