### PR TITLE
Add support for service externalTrafficPolicy

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: 'v2'
 name: 'media-servarr-base'
 description: 'Base chart for media-servarr charts'
 type: 'application'
-version: 0.14.0
+version: 0.15.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'bazarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.0
+version: 0.15.0
 appVersion: 1.6.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - 'radarr'
   - 'sonarr'
   - 'bazarr'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.14.0
 appVersion: 1.6.0

--- a/charts/cleanuparr/Chart.yaml
+++ b/charts/cleanuparr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'lidarr'
   - 'readarr'
   - 'whisparr'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.14.0
 appVersion: 2.9.16

--- a/charts/cleanuparr/Chart.yaml
+++ b/charts/cleanuparr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'whisparr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.0
+version: 0.15.0
 appVersion: 2.9.16
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/cleanuparr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/flaresolverr/Chart.yaml
+++ b/charts/flaresolverr/Chart.yaml
@@ -9,12 +9,12 @@ keywords:
   - 'bypass'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.0
+version: 0.15.0
 appVersion: v3.5.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/flaresolverr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -7,12 +7,12 @@ keywords:
   - 'homarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.44.0
+version: 0.45.0
 appVersion: v1.70.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/homarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -5,7 +5,7 @@ home: 'https://github.com/drinkataco/media-servarr/tree/main/charts/homarr'
 keywords:
   - 'dashboard'
   - 'homarr'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.44.0
 appVersion: v1.70.0

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -15,12 +15,12 @@ keywords:
   - 'jellyfin'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.13.0
+version: 0.14.0
 appVersion: 10.11.11
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - 'stream'
   - 'media'
   - 'jellyfin'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.13.0
 appVersion: 10.11.11

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - 'usenet'
   - 'manager'
   - 'lidarr'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 1.4.0
 appVersion: 3.1.0

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -11,12 +11,12 @@ keywords:
   - 'lidarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.4.0
+version: 1.5.0
 appVersion: 3.1.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/profilarr/Chart.yaml
+++ b/charts/profilarr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'profilarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.2.0
+version: 0.3.0
 appVersion: v1.1.5
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/profilarr/icon.png'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/profilarr'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."

--- a/charts/profilarr/Chart.yaml
+++ b/charts/profilarr/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - 'profiles'
   - 'formats'
   - 'profilarr'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.2.0
 appVersion: v1.1.5

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - 'download'
   - 'indexer'
   - 'prowlarr'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.24.0
 appVersion: 2.4.0

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'prowlarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.24.0
+version: 0.25.0
 appVersion: 2.4.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'usenet'
   - 'manager'
   - 'radarr'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 1.6.0
 appVersion: 6.2.1

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'radarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.6.0
+version: 1.7.0
 appVersion: 6.2.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'usenet'
   - 'manager'
   - 'readarr'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.14.0
 appVersion: 0.4.19-nightly

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -12,13 +12,13 @@ keywords:
   - 'readarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.0
+version: 0.15.0
 appVersion: 0.4.19-nightly
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png'
 deprecated: true
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -6,7 +6,7 @@ keywords:
   - 'usenet'
   - 'newsreader'
   - 'sabnzbd'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 1.1.0
 appVersion: 5.0.4

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -8,12 +8,12 @@ keywords:
   - 'sabnzbd'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.1.0
+version: 1.2.0
 appVersion: 5.0.4
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'sonarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.13.0
+version: 0.14.0
 appVersion: 4.0.19
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - 'usenet'
   - 'manager'
   - 'sonarr'
-kubeversion: ">=1.24.0-0"
+kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.13.0
 appVersion: 4.0.19

--- a/charts/tinymediamanager/Chart.yaml
+++ b/charts/tinymediamanager/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'tinymediamanager'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.1.0
+version: 1.2.0
 appVersion: 5.2.12
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/tinymediamanager'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'usenet'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.0
+version: 0.15.0
 appVersion: 4.1.3
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/transmission/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.14.0
+    version: 0.15.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -15,6 +15,9 @@ metadata:
   {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if (hasKey .Values.service "externalTrafficPolicy") }}
+  externalTrafficPolicy: '{{ .Values.service.externalTrafficPolicy }}'
+  {{- end }}
   ports:
     {{- range .Values.deployment.container.ports }}
     - port: {{ if .servicePort }}{{ .servicePort }}{{ else if .containerPort }}{{ .containerPort }}{{ else }}{{ $context.Values.application.port }}{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -147,6 +147,7 @@ serviceAccount:
 
 service:
   type: 'ClusterIP'
+  # externalTrafficPolicy: 'Local' # optional, only valid for NodePort/LoadBalancer services
   annotations: {}
     # example-annotation: "something"
   ports:


### PR DESCRIPTION
## Description

Adds support for setting `service.externalTrafficPolicy` on the base chart's Service resource. Also fixes the invalid `kubeversion` field name across all charts (renamed to `kubeVersion` to match the Helm spec — the lowercase form was silently ignored). Base chart and all dependent charts bumped 0.13.0 → 0.14.0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [x] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [ ] My changes are tested and proven to work.
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Testing

Rendered `charts/bazarr` locally with `helm template ... --set service.type=LoadBalancer --set service.externalTrafficPolicy=Local` and confirmed `externalTrafficPolicy: 'Local'` appears in the rendered Service spec. Also confirmed the field is omitted from the manifest when `service.externalTrafficPolicy` is unset. Not tested against a live cluster.

## Additional Information

`externalTrafficPolicy` is only valid when `service.type` is `NodePort` or `LoadBalancer`; the template gates the field with `hasKey` so it is omitted entirely unless explicitly set.