### PR TITLE
Expand README for discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,44 +6,212 @@
 
 ![media-servarr](./icon.png)
 
-This repository contains a collection of similar applications under the [servarr](https://wiki.servarr.com/) family, and some other useful related applications.
+A collection of opinionated Helm charts for self-hosted media automation on Kubernetes. All charts share a common base (`media-servarr-base`) so configuration patterns are consistent across every application.
 
-The aim of this repository is to be featureful, use repeatable code, and to be a testbed for me to play with a kubernetes helm chart.
+Covers the full [servarr](https://wiki.servarr.com/) stack — indexers, downloaders, and library managers for movies, TV, music, and books — plus supporting tools like a dashboard, subtitle manager, and media scraper.
 
 <!-- vim-md-toc format=bullets ignore=^TODO$ -->
-* [Usage](#usage)
 * [The Charts](#the-charts)
+* [Prerequisites](#prerequisites)
+* [Usage](#usage)
+* [Base Chart Features](#base-chart-features)
+* [Configuration Reference](#configuration-reference)
+  * [Secrets](#secrets)
+  * [Application config (ConfigMap-backed)](#application-config-configmap-backed)
+  * [Volumes and PersistentVolumeClaims](#volumes-and-persistentvolumeclaims)
+  * [Ingress](#ingress)
+  * [Metrics (Exportarr)](#metrics-exportarr)
+  * [Service](#service)
+  * [Service Account](#service-account)
+  * [Pod scheduling](#pod-scheduling)
 <!-- vim-md-toc END -->
+
+## The Charts
+
+| Chart | Application | Description |
+|---|---|---|
+| `bazarr` | [Bazarr](https://www.bazarr.media/) | Automatic subtitle downloader; companion to Sonarr and Radarr |
+| `cleanuparr` | [Cleanuparr](https://cleanuparr.github.io/Cleanuparr/) | Removes stalled, orphaned, and unwanted items from download clients |
+| `flaresolverr` | [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) | Proxy to bypass Cloudflare protection; used by Prowlarr |
+| `homarr` | [Homarr](https://homarr.dev/) | Dashboard for self-hosted services |
+| `jellyfin` | [Jellyfin](https://jellyfin.org/) | Open-source media server for movies, TV, and music |
+| `lidarr` | [Lidarr](https://lidarr.audio/) | Music library manager |
+| `profilarr` | [Profilarr](https://github.com/Dictionarry-Hub/profilarr) | Quality profile and custom format manager for the *arr stack |
+| `prowlarr` | [Prowlarr](https://prowlarr.com/) | Indexer manager and proxy for the *arr stack |
+| `radarr` | [Radarr](https://radarr.video/) | Movie library manager |
+| `readarr` _(deprecated)_ | [Readarr](https://readarr.com/) | Book library manager |
+| `sabnzbd` | [SABnzbd](https://sabnzbd.org/) | Usenet download client |
+| `sonarr` | [Sonarr](https://sonarr.tv/) | TV series library manager |
+| `tinymediamanager` | [tinyMediaManager](https://www.tinymediamanager.org/) | Media metadata scraper and manager |
+| `transmission` | [Transmission](https://transmissionbt.com) | BitTorrent download client |
+
+Each chart has its own `README.md` under [`./charts/<name>/`](./charts) with installation and configuration details.
+
+## Prerequisites
+
+- Kubernetes `>=1.24`
+- [Helm](https://helm.sh/) `>=3.12`
+- (Optional) [Prometheus Operator](https://github.com/prometheus-operator/kube-prometheus) CRDs if enabling `metrics`
 
 ## Usage
 
-Add the repository using:
+Add the Helm repository:
 
 ```bash
 helm repo add media-servarr https://media-servarr.shw.al/charts
+helm repo update
 ```
 
-And then view all available charts with
+List available charts:
 
 ```bash
 helm search repo media-servarr
 ```
 
-## The Charts
+Install a chart (Sonarr as an example):
 
-There are a number of charts available under the [./charts](./charts) - each with indiviual README instructions to help you get started.
+```bash
+helm install sonarr media-servarr/sonarr -f my-values.yaml
+```
 
-- Bazarr - [bazarr.media](https://www.bazarr.media/)
-- Cleanuparr - [cleanuparr.github.io](https://cleanuparr.github.io/Cleanuparr/)
-- Flaresolverr - [Flaresolverr/Flaresolverr](https://github.com/FlareSolverr/FlareSolverr)
-- Homarr - [homarr.dev](https://homarr.dev/)
-- Jellyfin - [jellyfin.org](https://jellyfin.org/)
-- Lidarr - [lidarr.audio](https://lidarr.audio/)
-- Profilarr - [github.com/Dictionarry-Hub/profilarr](https://github.com/Dictionarry-Hub/profilarr)
-- Prowlarr - [prowlarr.com](https://prowlarr.com/)
-- Radarr - [radarr.video](https://radarr.video/)
-- Readarr [DEPRECATED] - [readarr.com](https://readarr.com/)
-- Sabnzbd - [sabnzbd.org](https://sabnzbd.org/)
-- Sonarr - [sonarr.tv](https://sonarr.tv/)
-- tinyMediaManager - [tinymediamanager.org](https://www.tinymediamanager.org/)
-- Transmission - [transmissionbt.com](https://transmissionbt.com)
+Upgrade an existing release:
+
+```bash
+helm upgrade sonarr media-servarr/sonarr -f my-values.yaml
+```
+
+## Base Chart Features
+
+All charts are built on the shared `media-servarr-base` library. Key capabilities:
+
+- **Secret injection** — inline values or references to pre-existing Kubernetes Secrets; secrets can be substituted into ConfigMap-mounted config files at pod start via an init container
+- **Config-as-code** — application config files are managed as ConfigMaps and mounted read-write via an init container (to satisfy apps that crash on read-only mounts)
+- **PersistentVolumeClaims** — declarative PVC provisioning with support for `storageClassName`, `volumeName` (bind to a specific pre-existing PV), and label selectors
+- **Ingress** — single-host ingress with optional TLS and custom annotations (compatible with Traefik, nginx, etc.)
+- **Metrics / Exportarr** — optional [Exportarr](https://github.com/onedr0p/exportarr) sidecar and `ServiceMonitor` CRD for Prometheus scraping (supported on Radarr, Sonarr, Lidarr, Readarr, Prowlarr)
+- **Flexible volumes** — arbitrary volume types (NFS, emptyDir, ConfigMap, PVC, etc.) via the `deployment.volumes` map; a null entry defaults to `emptyDir: {}`
+- **Runtime customisation** — sidecar and init containers, node selectors, tolerations, affinity, pod/container security contexts, `runtimeClassName`, image pull secrets
+
+A JSON Schema for all values is provided at [`values.schema.json`](./values.schema.json). Editors with the [YAML Language Server](https://github.com/redhat-developer/yaml-language-server) (VS Code, nvim, etc.) will validate your values files against it automatically via the `yaml-language-server: $schema` modeline included in every `values.yaml`.
+
+## Configuration Reference
+
+All top-level keys are optional unless noted. The canonical reference is [`values.yaml`](./values.yaml); what follows is a summary of the main sections.
+
+### Secrets
+
+```yaml
+secrets:
+  - name: 'apiKey'          # key name used in config substitution ($apiKey) and Secret data
+    value: 'abc123'          # inline value — generates a Secret in-cluster
+  # - name: 'apiKey'
+  #   ref: 'my-k8s-secret'  # reference a pre-existing Secret instead
+```
+
+When `value` is set the chart creates a Kubernetes `Secret`. When `ref` is set the chart reads from a Secret you manage externally (e.g. via External Secrets Operator).
+
+### Application config (ConfigMap-backed)
+
+```yaml
+application:
+  port: 8989
+  urlBase: 'sonarr'
+  config:                     # null to disable ConfigMap management
+    filename: 'config.xml'
+    mountPath: '/config/config.xml'
+    secrets: ['apiKey']       # names to substitute as $apiKey in contents
+    contents: |
+      <Config>
+        <ApiKey>$apiKey</ApiKey>
+      </Config>
+```
+
+`config` can also be a list of entries to mount multiple config files.
+
+### Volumes and PersistentVolumeClaims
+
+```yaml
+deployment:
+  volumes:
+    config:                          # volume name; null → emptyDir
+      persistentVolumeClaim:
+        claimName: 'sonarr-config'
+    media:
+      nfs:
+        server: fileserver
+        path: /srv/media
+
+persistentVolumeClaims:
+  sonarr-config:
+    storageClassName: longhorn
+    accessMode: ReadWriteOnce        # singular string, not a list
+    requestStorage: 5Gi
+    volumeName: existing-pv-name     # optional: bind to a specific pre-existing PV
+```
+
+### Ingress
+
+```yaml
+ingress:
+  enabled: true
+  className: traefik
+  host: example.com
+  path: /sonarr                      # defaults to /urlBase
+  pathType: Prefix
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt
+  tls:
+    - secretName: example-tls
+      hosts: [example.com]
+```
+
+### Metrics (Exportarr)
+
+Supported on: Radarr, Sonarr, Lidarr, Readarr, Prowlarr.
+
+```yaml
+metrics:
+  enabled: true
+  app: sonarr                        # which *arr app to scrape
+  # apiref:                          # omit to use this chart's own apiKey secret
+  #   secret: my-existing-secret
+  #   keyname: apiKey
+```
+
+Requires Prometheus Operator CRDs (`ServiceMonitor`). Install [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first.
+
+### Service
+
+```yaml
+service:
+  type: ClusterIP                    # ClusterIP | NodePort | LoadBalancer | ExternalName
+  # externalTrafficPolicy: Local     # NodePort/LoadBalancer only
+  annotations: {}
+```
+
+### Service Account
+
+```yaml
+serviceAccount:
+  create: false
+  automount: true
+  name: default
+  imagePullSecrets:
+    - name: my-registry-secret
+```
+
+### Pod scheduling
+
+```yaml
+deployment:
+  runtimeClassName: nvidia
+  nodeSelector:
+    kubernetes.io/arch: amd64
+  tolerations:
+    - key: gpu
+      operator: Exists
+  affinity:
+    nodeAffinity: {}
+  podSecurityContext:
+    fsGroup: 1000
+```

--- a/README.md
+++ b/README.md
@@ -15,15 +15,7 @@ Covers the full [servarr](https://wiki.servarr.com/) stack — indexers, downloa
 * [Prerequisites](#prerequisites)
 * [Usage](#usage)
 * [Base Chart Features](#base-chart-features)
-* [Configuration Reference](#configuration-reference)
-  * [Secrets](#secrets)
-  * [Application config (ConfigMap-backed)](#application-config-configmap-backed)
-  * [Volumes and PersistentVolumeClaims](#volumes-and-persistentvolumeclaims)
-  * [Ingress](#ingress)
-  * [Metrics (Exportarr)](#metrics-exportarr)
-  * [Service](#service)
-  * [Service Account](#service-account)
-  * [Pod scheduling](#pod-scheduling)
+* [Configuration](#configuration)
 <!-- vim-md-toc END -->
 
 ## The Charts
@@ -45,7 +37,7 @@ Covers the full [servarr](https://wiki.servarr.com/) stack — indexers, downloa
 | `tinymediamanager` | [tinyMediaManager](https://www.tinymediamanager.org/) | Media metadata scraper and manager |
 | `transmission` | [Transmission](https://transmissionbt.com) | BitTorrent download client |
 
-Each chart has its own `README.md` under [`./charts/<name>/`](./charts) with installation and configuration details.
+Each chart has its own `README.md` under [`./charts/<name>/`](./charts) with per-app installation and configuration details.
 
 ## Prerequisites
 
@@ -86,132 +78,34 @@ All charts are built on the shared `media-servarr-base` library. Key capabilitie
 
 - **Secret injection** — inline values or references to pre-existing Kubernetes Secrets; secrets can be substituted into ConfigMap-mounted config files at pod start via an init container
 - **Config-as-code** — application config files are managed as ConfigMaps and mounted read-write via an init container (to satisfy apps that crash on read-only mounts)
-- **PersistentVolumeClaims** — declarative PVC provisioning with support for `storageClassName`, `volumeName` (bind to a specific pre-existing PV), and label selectors
+- **PersistentVolumeClaims** — declarative PVC provisioning with `storageClassName`, label selectors, and `volumeName` for binding to a pre-existing PV
 - **Ingress** — single-host ingress with optional TLS and custom annotations (compatible with Traefik, nginx, etc.)
-- **Metrics / Exportarr** — optional [Exportarr](https://github.com/onedr0p/exportarr) sidecar and `ServiceMonitor` CRD for Prometheus scraping (supported on Radarr, Sonarr, Lidarr, Readarr, Prowlarr)
-- **Flexible volumes** — arbitrary volume types (NFS, emptyDir, ConfigMap, PVC, etc.) via the `deployment.volumes` map; a null entry defaults to `emptyDir: {}`
+- **Metrics / Exportarr** — optional [Exportarr](https://github.com/onedr0p/exportarr) sidecar and `ServiceMonitor` CRD for Prometheus scraping (Radarr, Sonarr, Lidarr, Readarr, Prowlarr)
+- **Flexible volumes** — arbitrary volume types (NFS, emptyDir, ConfigMap, PVC, etc.) via the `deployment.volumes` map
 - **Runtime customisation** — sidecar and init containers, node selectors, tolerations, affinity, pod/container security contexts, `runtimeClassName`, image pull secrets
 
-A JSON Schema for all values is provided at [`values.schema.json`](./values.schema.json). Editors with the [YAML Language Server](https://github.com/redhat-developer/yaml-language-server) (VS Code, nvim, etc.) will validate your values files against it automatically via the `yaml-language-server: $schema` modeline included in every `values.yaml`.
+## Configuration
 
-## Configuration Reference
+For the full list of value keys, their types, and inline documentation:
 
-All top-level keys are optional unless noted. The canonical reference is [`values.yaml`](./values.yaml); what follows is a summary of the main sections.
+- **Per-chart guides** — each chart has its own [`README.md`](./charts) with an installation walkthrough and worked examples.
+- **JSON Schema** — [`values.schema.json`](./values.schema.json) validates every value path. Editors with the [YAML Language Server](https://github.com/redhat-developer/yaml-language-server) pick it up automatically via the modeline at the top of each `values.yaml`.
+- **Default values** — [`values.yaml`](./values.yaml) is the canonical reference for defaults and shape.
 
-### Secrets
+The most distinctive pattern in this repo is **config-as-code with secret substitution**: application config lives in `values.yaml`, gets rendered to a ConfigMap, and secrets are substituted at pod start:
 
 ```yaml
 secrets:
-  - name: 'apiKey'          # key name used in config substitution ($apiKey) and Secret data
-    value: 'abc123'          # inline value — generates a Secret in-cluster
-  # - name: 'apiKey'
-  #   ref: 'my-k8s-secret'  # reference a pre-existing Secret instead
-```
+  - name: apiKey
+    value: 'abc123'          # or: ref: 'my-existing-secret'
 
-When `value` is set the chart creates a Kubernetes `Secret`. When `ref` is set the chart reads from a Secret you manage externally (e.g. via External Secrets Operator).
-
-### Application config (ConfigMap-backed)
-
-```yaml
 application:
-  port: 8989
-  urlBase: 'sonarr'
-  config:                     # null to disable ConfigMap management
-    filename: 'config.xml'
-    mountPath: '/config/config.xml'
-    secrets: ['apiKey']       # names to substitute as $apiKey in contents
+  config:
+    filename: config.xml
+    mountPath: /config/config.xml
+    secrets: [apiKey]        # substituted as $apiKey in contents
     contents: |
       <Config>
         <ApiKey>$apiKey</ApiKey>
       </Config>
-```
-
-`config` can also be a list of entries to mount multiple config files.
-
-### Volumes and PersistentVolumeClaims
-
-```yaml
-deployment:
-  volumes:
-    config:                          # volume name; null → emptyDir
-      persistentVolumeClaim:
-        claimName: 'sonarr-config'
-    media:
-      nfs:
-        server: fileserver
-        path: /srv/media
-
-persistentVolumeClaims:
-  sonarr-config:
-    storageClassName: longhorn
-    accessMode: ReadWriteOnce        # singular string, not a list
-    requestStorage: 5Gi
-    volumeName: existing-pv-name     # optional: bind to a specific pre-existing PV
-```
-
-### Ingress
-
-```yaml
-ingress:
-  enabled: true
-  className: traefik
-  host: example.com
-  path: /sonarr                      # defaults to /urlBase
-  pathType: Prefix
-  annotations:
-    cert-manager.io/cluster-issuer: letsencrypt
-  tls:
-    - secretName: example-tls
-      hosts: [example.com]
-```
-
-### Metrics (Exportarr)
-
-Supported on: Radarr, Sonarr, Lidarr, Readarr, Prowlarr.
-
-```yaml
-metrics:
-  enabled: true
-  app: sonarr                        # which *arr app to scrape
-  # apiref:                          # omit to use this chart's own apiKey secret
-  #   secret: my-existing-secret
-  #   keyname: apiKey
-```
-
-Requires Prometheus Operator CRDs (`ServiceMonitor`). Install [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first.
-
-### Service
-
-```yaml
-service:
-  type: ClusterIP                    # ClusterIP | NodePort | LoadBalancer | ExternalName
-  # externalTrafficPolicy: Local     # NodePort/LoadBalancer only
-  annotations: {}
-```
-
-### Service Account
-
-```yaml
-serviceAccount:
-  create: false
-  automount: true
-  name: default
-  imagePullSecrets:
-    - name: my-registry-secret
-```
-
-### Pod scheduling
-
-```yaml
-deployment:
-  runtimeClassName: nvidia
-  nodeSelector:
-    kubernetes.io/arch: amd64
-  tolerations:
-    - key: gpu
-      operator: Exists
-  affinity:
-    nodeAffinity: {}
-  podSecurityContext:
-    fsGroup: 1000
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ All charts share the common base (`media-servarr-base`) so configuration pattern
 * [The Charts](#the-charts)
 * [Prerequisites](#prerequisites)
 * [Usage](#usage)
-* [Base Chart Features](#base-chart-features)
 * [Configuration](#configuration)
 
 ## The Charts
@@ -70,19 +69,9 @@ Upgrade an existing release:
 helm upgrade sonarr media-servarr/sonarr -f my-values.yaml
 ```
 
-## Base Chart Features
-
-All charts are built on the shared `media-servarr-base` library. Key capabilities:
-
-- **Secret injection** — inline values or references to pre-existing Kubernetes Secrets; secrets can be substituted into ConfigMap-mounted config files at pod start via an init container
-- **Config-as-code** — application config files are managed as ConfigMaps and mounted read-write via an init container (to satisfy apps that crash on read-only mounts)
-- **PersistentVolumeClaims** — declarative PVC provisioning with `storageClassName`, label selectors, and `volumeName` for binding to a pre-existing PV
-- **Ingress** — single-host ingress with optional TLS and custom annotations (compatible with Traefik, nginx, etc.)
-- **Metrics / Exportarr** — optional [Exportarr](https://github.com/onedr0p/exportarr) sidecar and `ServiceMonitor` CRD for Prometheus scraping (Radarr, Sonarr, Lidarr, Readarr, Prowlarr)
-- **Flexible volumes** — arbitrary volume types (NFS, emptyDir, ConfigMap, PVC, etc.) via the `deployment.volumes` map
-- **Runtime customisation** — sidecar and init containers, node selectors, tolerations, affinity, pod/container security contexts, `runtimeClassName`, image pull secrets
-
 ## Configuration
+
+The `media-servarr-base` library gives every chart the same building blocks: secret injection (inline or by reference), config-as-code via a ConfigMap-mounted config file, declarative PersistentVolumeClaims (including binding to a pre-existing PV via `volumeName`), ingress with optional TLS, an optional [Exportarr](https://github.com/onedr0p/exportarr) metrics sidecar for the *arr apps, and the usual pod-scheduling knobs.
 
 For the full list of value keys, their types, and inline documentation:
 
@@ -90,12 +79,12 @@ For the full list of value keys, their types, and inline documentation:
 - **JSON Schema** — [`values.schema.json`](./values.schema.json) validates every value path. Editors with the [YAML Language Server](https://github.com/redhat-developer/yaml-language-server) pick it up automatically via the modeline at the top of each `values.yaml`.
 - **Default values** — [`values.yaml`](./values.yaml) is the canonical reference for defaults and shape.
 
-The most distinctive pattern in this repo is **config-as-code with secret substitution**: application config lives in `values.yaml`, gets rendered to a ConfigMap, and secrets are substituted at pod start:
+A distinctive pattern used in these charts is the **config-as-code with secret substitution**: application config lives in `values.yaml`, gets rendered to a ConfigMap, and secrets are substituted at pod start, allowing use to use secrets and configmap without having to commit their values:
 
 ```yaml
 secrets:
   - name: apiKey
-    value: 'abc123'          # or: ref: 'my-existing-secret'
+    ref: 'my-api-key'
 
 application:
   config:

--- a/README.md
+++ b/README.md
@@ -6,36 +6,34 @@
 
 ![media-servarr](./icon.png)
 
-A collection of opinionated Helm charts for self-hosted media automation on Kubernetes. All charts share a common base (`media-servarr-base`) so configuration patterns are consistent across every application.
+A collection of Helm charts for self-hosted media - primarily built around the [Servarr](https://wiki.servarr.com/) family of charts, with some complementary charts here and there.
 
-Covers the full [servarr](https://wiki.servarr.com/) stack — indexers, downloaders, and library managers for movies, TV, music, and books — plus supporting tools like a dashboard, subtitle manager, and media scraper.
+All charts share the common base (`media-servarr-base`) so configuration patterns are consistent across every application.
 
-<!-- vim-md-toc format=bullets ignore=^TODO$ -->
 * [The Charts](#the-charts)
 * [Prerequisites](#prerequisites)
 * [Usage](#usage)
 * [Base Chart Features](#base-chart-features)
 * [Configuration](#configuration)
-<!-- vim-md-toc END -->
 
 ## The Charts
 
 | Chart | Application | Description |
 |---|---|---|
-| `bazarr` | [Bazarr](https://www.bazarr.media/) | Automatic subtitle downloader; companion to Sonarr and Radarr |
-| `cleanuparr` | [Cleanuparr](https://cleanuparr.github.io/Cleanuparr/) | Removes stalled, orphaned, and unwanted items from download clients |
-| `flaresolverr` | [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) | Proxy to bypass Cloudflare protection; used by Prowlarr |
-| `homarr` | [Homarr](https://homarr.dev/) | Dashboard for self-hosted services |
-| `jellyfin` | [Jellyfin](https://jellyfin.org/) | Open-source media server for movies, TV, and music |
-| `lidarr` | [Lidarr](https://lidarr.audio/) | Music library manager |
-| `profilarr` | [Profilarr](https://github.com/Dictionarry-Hub/profilarr) | Quality profile and custom format manager for the *arr stack |
-| `prowlarr` | [Prowlarr](https://prowlarr.com/) | Indexer manager and proxy for the *arr stack |
-| `radarr` | [Radarr](https://radarr.video/) | Movie library manager |
-| `readarr` _(deprecated)_ | [Readarr](https://readarr.com/) | Book library manager |
-| `sabnzbd` | [SABnzbd](https://sabnzbd.org/) | Usenet download client |
-| `sonarr` | [Sonarr](https://sonarr.tv/) | TV series library manager |
-| `tinymediamanager` | [tinyMediaManager](https://www.tinymediamanager.org/) | Media metadata scraper and manager |
-| `transmission` | [Transmission](https://transmissionbt.com) | BitTorrent download client |
+| [`bazarr`](./charts/bazarr) | [Bazarr](https://www.bazarr.media/) | Automatic subtitle downloader; companion to Sonarr and Radarr |
+| [`cleanuparr`](./charts/cleanuparr) | [Cleanuparr](https://cleanuparr.github.io/Cleanuparr/) | Removes stalled, orphaned, and unwanted items from download clients |
+| [`flaresolverr`](./charts/flaresolverr) | [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) | Proxy to bypass Cloudflare protection; used by Prowlarr |
+| [`homarr`](./charts/homarr) | [Homarr](https://homarr.dev/) | Dashboard for self-hosted services |
+| [`jellyfin`](./charts/jellyfin) | [Jellyfin](https://jellyfin.org/) | Open-source media server for movies, TV, and music |
+| [`lidarr`](./charts/lidarr) | [Lidarr](https://lidarr.audio/) | Music library manager |
+| [`profilarr`](./charts/profilarr) | [Profilarr](https://github.com/Dictionarry-Hub/profilarr) | Quality profile and custom format manager for the *arr stack |
+| [`prowlarr`](./charts/prowlarr) | [Prowlarr](https://prowlarr.com/) | Indexer manager and proxy for the *arr stack |
+| [`radarr`](./charts/radarr) | [Radarr](https://radarr.video/) | Movie library manager |
+| [`readarr`](./charts/readarr) _(deprecated)_ | [Readarr](https://readarr.com/) | Book library manager |
+| [`sabnzbd`](./charts/sabnzbd) | [SABnzbd](https://sabnzbd.org/) | Usenet download client |
+| [`sonarr`](./charts/sonarr) | [Sonarr](https://sonarr.tv/) | TV series library manager |
+| [`tinymediamanager`](./charts/tinymediamanager) | [tinyMediaManager](https://www.tinymediamanager.org/) | Media metadata scraper and manager |
+| [`transmission`](./charts/transmission) | [Transmission](https://transmissionbt.com) | BitTorrent download client |
 
 Each chart has its own `README.md` under [`./charts/<name>/`](./charts) with per-app installation and configuration details.
 
@@ -43,7 +41,7 @@ Each chart has its own `README.md` under [`./charts/<name>/`](./charts) with per
 
 - Kubernetes `>=1.24`
 - [Helm](https://helm.sh/) `>=3.12`
-- (Optional) [Prometheus Operator](https://github.com/prometheus-operator/kube-prometheus) CRDs if enabling `metrics`
+- (Optional) [Prometheus Operator](https://github.com/prometheus-operator/kube-prometheus) CRDs if enabling `metrics` where available (see [exportarr](https://github.com/onedr0p/exportarr))
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -17,22 +17,22 @@ All charts share the common base (`media-servarr-base`) so configuration pattern
 
 ## The Charts
 
-| Chart | Application | Description |
-|---|---|---|
-| [`bazarr`](./charts/bazarr) | [Bazarr](https://www.bazarr.media/) | Automatic subtitle downloader; companion to Sonarr and Radarr |
-| [`cleanuparr`](./charts/cleanuparr) | [Cleanuparr](https://cleanuparr.github.io/Cleanuparr/) | Removes stalled, orphaned, and unwanted items from download clients |
-| [`flaresolverr`](./charts/flaresolverr) | [FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) | Proxy to bypass Cloudflare protection; used by Prowlarr |
-| [`homarr`](./charts/homarr) | [Homarr](https://homarr.dev/) | Dashboard for self-hosted services |
-| [`jellyfin`](./charts/jellyfin) | [Jellyfin](https://jellyfin.org/) | Open-source media server for movies, TV, and music |
-| [`lidarr`](./charts/lidarr) | [Lidarr](https://lidarr.audio/) | Music library manager |
-| [`profilarr`](./charts/profilarr) | [Profilarr](https://github.com/Dictionarry-Hub/profilarr) | Quality profile and custom format manager for the *arr stack |
-| [`prowlarr`](./charts/prowlarr) | [Prowlarr](https://prowlarr.com/) | Indexer manager and proxy for the *arr stack |
-| [`radarr`](./charts/radarr) | [Radarr](https://radarr.video/) | Movie library manager |
-| [`readarr`](./charts/readarr) _(deprecated)_ | [Readarr](https://readarr.com/) | Book library manager |
-| [`sabnzbd`](./charts/sabnzbd) | [SABnzbd](https://sabnzbd.org/) | Usenet download client |
-| [`sonarr`](./charts/sonarr) | [Sonarr](https://sonarr.tv/) | TV series library manager |
-| [`tinymediamanager`](./charts/tinymediamanager) | [tinyMediaManager](https://www.tinymediamanager.org/) | Media metadata scraper and manager |
-| [`transmission`](./charts/transmission) | [Transmission](https://transmissionbt.com) | BitTorrent download client |
+| Chart | Description |
+|---|---|
+| [`bazarr`](./charts/bazarr) | Automatic subtitle downloader; companion to Sonarr and Radarr — [bazarr.media](https://www.bazarr.media/) |
+| [`cleanuparr`](./charts/cleanuparr) | Removes stalled, orphaned, and unwanted items from download clients — [cleanuparr.github.io](https://cleanuparr.github.io/Cleanuparr/) |
+| [`flaresolverr`](./charts/flaresolverr) | Proxy to bypass Cloudflare protection; used by Prowlarr — [github.com/FlareSolverr](https://github.com/FlareSolverr/FlareSolverr) |
+| [`homarr`](./charts/homarr) | Dashboard for self-hosted services — [homarr.dev](https://homarr.dev/) |
+| [`jellyfin`](./charts/jellyfin) | Open-source media server for movies, TV, and music — [jellyfin.org](https://jellyfin.org/) |
+| [`lidarr`](./charts/lidarr) | Music library manager — [lidarr.audio](https://lidarr.audio/) |
+| [`profilarr`](./charts/profilarr) | Quality profile and custom format manager for the *arr stack — [github.com/Dictionarry-Hub/profilarr](https://github.com/Dictionarry-Hub/profilarr) |
+| [`prowlarr`](./charts/prowlarr) | Indexer manager and proxy for the *arr stack — [prowlarr.com](https://prowlarr.com/) |
+| [`radarr`](./charts/radarr) | Movie library manager — [radarr.video](https://radarr.video/) |
+| [`readarr`](./charts/readarr) _(deprecated)_ | Book library manager — [readarr.com](https://readarr.com/) |
+| [`sabnzbd`](./charts/sabnzbd) | Usenet download client — [sabnzbd.org](https://sabnzbd.org/) |
+| [`sonarr`](./charts/sonarr) | TV series library manager — [sonarr.tv](https://sonarr.tv/) |
+| [`tinymediamanager`](./charts/tinymediamanager) | Media metadata scraper and manager — [tinymediamanager.org](https://www.tinymediamanager.org/) |
+| [`transmission`](./charts/transmission) | BitTorrent download client — [transmissionbt.com](https://transmissionbt.com) |
 
 Each chart has its own `README.md` under [`./charts/<name>/`](./charts) with per-app installation and configuration details.
 

--- a/charts/bazarr/README.md
+++ b/charts/bazarr/README.md
@@ -25,7 +25,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install bazarr media-servarr/bazarr
 ```
@@ -117,7 +117,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'bazarr-config'
+        claimName: 'bazarr-config'
 ```
 
 By default, a PersistentVolumeClaim will be provisioned for the `config` named `bazarr-config`.

--- a/charts/bazarr/README.md
+++ b/charts/bazarr/README.md
@@ -34,7 +34,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Secrets
 
@@ -69,8 +69,8 @@ The following example expects to have secrets set up for Radarr and Sonarr API k
 
 ```yaml
 application:
-  port: 8686 # default UI port
-  urlBase: 'radarr' # default web base path
+  port: 6767 # default UI port
+  urlBase: 'bazarr' # default web base path
   config:
     contents: |
       general:
@@ -97,7 +97,7 @@ application:
       - 'radarrApiKey'
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:
@@ -162,7 +162,7 @@ metrics:
 
 It is recommended to install [kube-prometheus chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first for the CRD to be supported. It is not included as a dependency by default in this package!
 
-Unless changed with `metrics.port.number` you can then consume metrics over port `9702`.
+Unless changed with `metrics.port.number` you can then consume metrics over port `9700`.
 
 ### Advanced
 

--- a/charts/bazarr/README.md
+++ b/charts/bazarr/README.md
@@ -128,6 +128,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/cleanuparr/README.md
+++ b/charts/cleanuparr/README.md
@@ -34,7 +34,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Secrets
 

--- a/charts/cleanuparr/README.md
+++ b/charts/cleanuparr/README.md
@@ -84,6 +84,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/cleanuparr/README.md
+++ b/charts/cleanuparr/README.md
@@ -25,7 +25,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install cleanuparr media-servarr/cleanuparr
 ```
@@ -73,7 +73,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'cleanuparr-config'
+        claimName: 'cleanuparr-config'
 ```
 
 By default, a PersistentVolumeClaim will be provisioned for the `config` named `cleanuparr-config`.

--- a/charts/flaresolverr/README.md
+++ b/charts/flaresolverr/README.md
@@ -23,7 +23,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install radarr media-servarr/flaresolverr
 ```

--- a/charts/flaresolverr/README.md
+++ b/charts/flaresolverr/README.md
@@ -11,6 +11,7 @@ This README covers the basics of customising and installation
 * [Configuration](#configuration)
   * [Access](#access)
   * [Usage](#usage)
+  * [Ingress](#ingress)
   * [Metrics](#metrics)
   * [Advanced](#advanced)
 * [Upgrading](#upgrading)
@@ -25,12 +26,12 @@ Install this helm chart using the following command:
 ```bash
 helm repo add media-servarr https://media-servarr.shw.al/charts
 
-helm install radarr media-servarr/flaresolverr
+helm install flaresolverr media-servarr/flaresolverr
 ```
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 Unlike other charts in this collection, configuration options are a lot more limited due to the nature of this application.
 
@@ -46,9 +47,23 @@ This application is useful alongside [prowlarr](../prowlarr), allowing you to ac
 
 By default, the internal URL will be `http://flaresolverr.{namespace}.svc.cluster.local:8191`
 
+### Ingress
+
+Flaresolverr is typically consumed in-cluster (by Prowlarr etc.) rather than externally, but ingress is enabled by default. Override host and TLS as needed:
+
+```yaml
+ingress:
+  enabled: true
+  host: 'example.com'
+  tls:
+    # Your TLS settings...
+```
+
+Disable ingress entirely with `ingress.enabled: false` if you only need in-cluster access.
+
 ### Metrics
 
-Flaresolver comes with out-of-the-box support for prometheus. Just enable by setting the following enviornment variables:
+Flaresolverr exposes Prometheus metrics natively (not via Exportarr). Enable it by setting the following environment variables on the container:
 
 ```yaml
 deployment:
@@ -60,9 +75,7 @@ deployment:
       value: '9702'
 ```
 
-It is recommended to install [kube-prometheus chart](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) first for the CRD to be supported. It is not included as a dependency by default in this package!
-
-Unless changed with `metrics.port.number` you can then consume metrics over port `9704`.
+Metrics are then available on port `9702` (or whatever `PROMETHEUS_PORT` you set). To have Prometheus scrape them, install the [kube-prometheus](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) chart first and add a `ServiceMonitor` for this Service.
 
 ### Advanced
 

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -80,6 +80,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -32,7 +32,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Application Configuration
 
@@ -65,9 +65,13 @@ deployment:
       nfs:
         server: 'fileserver'
         path: '/srv/homarr/icons'
+    # DB files — a PVC is provisioned by default (see below)
+    data:
+      persistentVolumeClaim:
+        claimName: 'homarr-data'
 ```
 
-By default, a PersistentVolumeClaim will be provisioned for the `data`, but `emptyDir: {}` will be used for config and icons, unless otherwise specified in your `values.yaml`
+By default a PersistentVolumeClaim is provisioned for `data`; `emptyDir: {}` is used for the other two unless overridden in your `values.yaml`.
 
 ```yaml
 persistentVolumeClaims:
@@ -83,12 +87,13 @@ persistentVolumeClaims:
 
 ### Ingress
 
-Ingress can be enabled, and you can customise the default host, path, and TLS settings:
+Ingress is enabled by default and Homarr is served from the root path (`/`). Override host and TLS as needed:
 
 ```yaml
 ingress:
   enabled: true
   host: 'example.com'
+  path: '/'
   tls:
     # Your TLS settings...
 ```

--- a/charts/homarr/README.md
+++ b/charts/homarr/README.md
@@ -23,7 +23,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install homarr media-servarr/homarr
 ```
@@ -58,7 +58,7 @@ deployment:
     # Dashboard (config) files
     app-data-configs:
       persistentVolumeClaim:
-        name: 'my-pv-claim1'
+        claimName: 'my-pv-claim1'
     # Dashboard Icons
     app-data-icons:
       # Example direct NFS mount without need for PV

--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -24,7 +24,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install jellyfin media-servarr/jellyfin
 ```
@@ -89,7 +89,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'jellyfin-config'
+        claimName: 'jellyfin-config'
     ebooks:
       nfs:
         server: 'fileserver.local'

--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -33,13 +33,13 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Application Configuration
 
 By default, base configuration is defined using a ConfigMap - defined by default in `./values.yaml` in `application.config`. You can change values in the contents, such as the url base in your custom `values.yaml`
 
-Jellyfin has multiple config files which we can create ConfigMaps for. By default, we manage network.xml and system.xml, but we could also encoding.xml.
+Jellyfin has multiple config files which we can create ConfigMaps for. By default, we manage network.xml and system.xml, but we could also add encoding.xml.
 
 ```yaml
 application:
@@ -65,7 +65,7 @@ application:
       mountPath: '/config/config/encoding.xml'
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:

--- a/charts/jellyfin/README.md
+++ b/charts/jellyfin/README.md
@@ -107,6 +107,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/lidarr/README.md
+++ b/charts/lidarr/README.md
@@ -34,7 +34,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Secrets
 
@@ -60,13 +60,13 @@ By default, base configuration is defined using a ConfigMap - defined by default
 ```yaml
 application:
   port: 8686 # default UI port
-  urlBase: 'radarr' # default web base path
+  urlBase: 'lidarr' # default web base path
   config:
     filename: 'config.xml'
     contents: |
       <Config>
         ...
-        <UrlBase>music</UrlBase>
+        <UrlBase>lidarr</UrlBase>
         <ApiKey>$apiKey</ApiKey>
         <Port>8686</Port>
         ...
@@ -75,7 +75,7 @@ application:
     mountPath: '/config/config.xml'
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:

--- a/charts/lidarr/README.md
+++ b/charts/lidarr/README.md
@@ -25,7 +25,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install lidarr media-servarr/lidarr
 ```
@@ -97,7 +97,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'lidarr-config'
+        claimName: 'lidarr-config'
     downloads:
       nfs:
         server: 'fileserver.local'

--- a/charts/lidarr/README.md
+++ b/charts/lidarr/README.md
@@ -116,6 +116,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/profilarr/README.md
+++ b/charts/profilarr/README.md
@@ -72,6 +72,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '5Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/profilarr/README.md
+++ b/charts/profilarr/README.md
@@ -23,7 +23,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install profilarr media-servarr/profilarr
 ```

--- a/charts/profilarr/README.md
+++ b/charts/profilarr/README.md
@@ -32,7 +32,7 @@ By default, this chart exposes Profilarr at `http://profilarr.local/`
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Application Configuration
 

--- a/charts/prowlarr/README.md
+++ b/charts/prowlarr/README.md
@@ -34,7 +34,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Secrets
 
@@ -75,7 +75,7 @@ application:
     mountPath: '/config/config.xml'
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:
@@ -85,10 +85,9 @@ application:
 
 ### Volumes
 
-Three volumes are available by default:
+Only one volume is mounted by default:
 
-- **config** - General config data, where the sqlite database exists, for example
-- **downloads** - Downloads folder for monitoring
+- **config** — General config data, where the sqlite database lives
 
 ```yaml
 deployment:

--- a/charts/prowlarr/README.md
+++ b/charts/prowlarr/README.md
@@ -25,7 +25,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install prowlarr media-servarr/prowlarr
 ```
@@ -96,7 +96,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'prowlarr-config'
+        claimName: 'prowlarr-config'
 ```
 
 By default, a PersistentVolumeClaim will be provisioned for the `config`.

--- a/charts/prowlarr/README.md
+++ b/charts/prowlarr/README.md
@@ -106,6 +106,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/radarr/README.md
+++ b/charts/radarr/README.md
@@ -34,7 +34,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Secrets
 
@@ -62,6 +62,7 @@ application:
   port: 7878 # default UI port
   urlBase: 'radarr' # default web base path
   config:
+    filename: 'config.xml'
     contents: |
       <Config>
         ...
@@ -70,9 +71,11 @@ application:
         <Port>7878</Port>
         ...
       </Config>
+    secrets: [ 'apiKey' ]
+    mountPath: '/config/config.xml'
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:

--- a/charts/radarr/README.md
+++ b/charts/radarr/README.md
@@ -116,6 +116,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/radarr/README.md
+++ b/charts/radarr/README.md
@@ -25,7 +25,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install radarr media-servarr/radarr
 ```
@@ -94,7 +94,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'radarr-config'
+        claimName: 'radarr-config'
     downloads:
       nfs:
         server: 'fileserver.local'

--- a/charts/readarr/README.md
+++ b/charts/readarr/README.md
@@ -38,7 +38,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Secrets
 
@@ -66,6 +66,7 @@ application:
   port: 8787 # default UI port
   urlBase: 'readarr' # default web base path
   config:
+    filename: 'config.xml'
     contents: |
       <Config>
         ...
@@ -74,9 +75,11 @@ application:
         <Port>8787</Port>
         ...
       </Config>
+    secrets: [ 'apiKey' ]
+    mountPath: '/config/config.xml'
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:
@@ -135,6 +138,8 @@ ingress:
 ```
 
 ### Metrics
+
+> Since Readarr is retired, expect Exportarr's Readarr support to receive no further updates. It may still work against the current release, but is unlikely to track future upstream changes.
 
 Enabling metrics enables a sidecar container being attached for [exportarr](https://github.com/onedr0p/exportarr/) - and a ServiceMonitor CRD to be consumed by the [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) package.
 

--- a/charts/readarr/README.md
+++ b/charts/readarr/README.md
@@ -29,7 +29,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install readarr media-servarr/readarr
 ```
@@ -98,7 +98,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'readarr-config'
+        claimName: 'readarr-config'
     downloads:
       nfs:
         server: 'fileserver.local'

--- a/charts/readarr/README.md
+++ b/charts/readarr/README.md
@@ -120,6 +120,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/sabnzbd/README.md
+++ b/charts/sabnzbd/README.md
@@ -34,7 +34,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Secrets
 
@@ -96,7 +96,7 @@ application:
       # priority = 0
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:
@@ -106,10 +106,11 @@ application:
 
 ### Volumes
 
-Three volumes are available by default:
+Only one volume is mounted by default:
 
-- **config** - General config data
-- **downloads** - Downloads folder, with {complete, incomplete} subdirectories
+- **config** — General config data. Downloads land under `/config/Downloads` (as `complete/` and `incomplete/` subdirectories) unless you override `download_dir` / `complete_dir` in the config file.
+
+For an external downloads volume, add a `downloads` volume and update `download_dir` / `complete_dir` in the config to point at it:
 
 ```yaml
 deployment:
@@ -124,7 +125,7 @@ deployment:
         path: '/srv/downloads/'
 ```
 
-By default, a PersistentVolumeClaim will be provisioned for the `config`, but `emptyDir: {}` will be used for downloads, unless otherwise specified in your `values.yaml`
+A PersistentVolumeClaim is provisioned for `config` by default. Any additional volumes you declare default to `emptyDir: {}` unless configured otherwise in your `values.yaml`.
 
 ```yaml
 persistentVolumeClaims:
@@ -153,14 +154,14 @@ ingress:
 
 Enabling metrics enables a sidecar container being attached for [exportarr](https://github.com/onedr0p/exportarr/) - and a ServiceMonitor CRD to be consumed by the [kube-prometheus](https://github.com/prometheus-operator/kube-prometheus) package.
 
-By default, Exportarr reads the `apiKey` from this chart's Secret. If you need Exportarr to read a different Secret/key, set `metrics.apiref`.
+Exportarr's SABnzbd support authenticates with the **nzb key** (not the apiKey). The base chart's default is to pass this chart's `apiKey`, so for SABnzbd you must point `metrics.apiref` at the release's `nzbKey` (or an equivalent Secret you manage):
 
 ```yaml
 metrics:
   enabled: true
   apiref:
-    secret: 'my-existing-secret'
-    keyname: 'apiKey'
+    secret: '{{ .Release.Name }}-sabnzbd'  # this chart's own Secret
+    keyname: 'nzbKey'
   env: []
 ```
 

--- a/charts/sabnzbd/README.md
+++ b/charts/sabnzbd/README.md
@@ -133,6 +133,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/sabnzbd/README.md
+++ b/charts/sabnzbd/README.md
@@ -25,7 +25,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install sabnzbd media-servarr/sabnzbd
 ```
@@ -117,7 +117,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'sabnzbd-config'
+        claimName: 'sabnzbd-config'
     downloads:
       nfs:
         server: 'fileserver.local'

--- a/charts/sonarr/README.md
+++ b/charts/sonarr/README.md
@@ -25,7 +25,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install sonarr media-servarr/sonarr
 ```
@@ -94,7 +94,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'sonarr-config'
+        claimName: 'sonarr-config'
     downloads:
       nfs:
         server: 'fileserver.local'

--- a/charts/sonarr/README.md
+++ b/charts/sonarr/README.md
@@ -113,6 +113,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/sonarr/README.md
+++ b/charts/sonarr/README.md
@@ -34,7 +34,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Secrets
 
@@ -72,7 +72,7 @@ application:
       </Config>
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:

--- a/charts/tinymediamanager/README.md
+++ b/charts/tinymediamanager/README.md
@@ -92,6 +92,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '20Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/tinymediamanager/README.md
+++ b/charts/tinymediamanager/README.md
@@ -23,7 +23,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install tinymediamanager media-servarr/tinymediamanager
 ```

--- a/charts/tinymediamanager/README.md
+++ b/charts/tinymediamanager/README.md
@@ -32,7 +32,7 @@ By default, this chart exposes tinyMediaManager at `http://tinymediamanager.loca
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Application Configuration
 
@@ -49,7 +49,9 @@ application:
     mountPath: '/app/launcher-extra.yml'
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+The chart exposes two container ports: `http` (`4000`, the web UI) and `api` (`7878`, the REST API used by companion apps). Both are declared in `deployment.container.ports` and exposed on the Service.
+
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -25,7 +25,7 @@ This README covers the basics of customising and installation
 Install this helm chart using the following command:
 
 ```bash
-helm repo add mediar-servarr https://media-servarr.shw.al/charts
+helm repo add media-servarr https://media-servarr.shw.al/charts
 
 helm install transmission media-servarr/transmission
 ```
@@ -95,7 +95,7 @@ deployment:
   volumes:
     config: # The key will be the volume name
       persistentVolumeClaim:
-        name: 'transmission-config'
+        claimName: 'transmission-config'
     downloads:
       nfs:
         server: 'fileserver.local'

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -111,6 +111,7 @@ persistentVolumeClaims:
     accessMode: 'ReadWriteOnce'
     requestStorage: '1Gi'
     storageClassName: 'manual'
+    # volumeName: 'existing-pv-name'  # optional: bind this PVC to a specific pre-existing PV
     selector:
       matchLabels:
         type: 'local'

--- a/charts/transmission/README.md
+++ b/charts/transmission/README.md
@@ -12,7 +12,8 @@ This README covers the basics of customising and installation
   * [Secrets](#secrets)
   * [Application Configuration](#application-configuration)
   * [Volumes](#volumes)
-  * [Ingress Configuration](#ingress-configuration)
+  * [Service](#service)
+  * [Ingress](#ingress)
   * [VPN Sidecar](#vpn-sidecar)
   * [Advanced](#advanced)
 * [Upgrading](#upgrading)
@@ -34,7 +35,7 @@ Pointing the host `media-servarr.local` to your kubernetes cluster will then all
 
 ## Configuration
 
-Here is some example of some configuration you may want to override (and include in installation with `-f myvalues.yaml`
+Here are some examples of configuration you may want to override (and include in installation with `-f myvalues.yaml`).
 
 ### Secrets
 
@@ -74,7 +75,7 @@ application:
     mountPath: '/config/settings.json'
 ```
 
-You can prevent a ConfigMap being create and the configuration being managed as a kubernetes resource by defing the config as null. For example;
+You can prevent a ConfigMap being created and the configuration being managed as a kubernetes resource by defining the config as null. For example:
 
 ```yaml
 application:
@@ -84,10 +85,10 @@ application:
 
 ### Volumes
 
-Three volumes are available by default:
+Two volumes are used by default:
 
-- **config** - General config data - where settings exist
-- **downloads** - Downloads folder
+- **config** — General config data, where settings live
+- **downloads** — Downloads folder
 
 ```yaml
 deployment:
@@ -115,13 +116,26 @@ persistentVolumeClaims:
         type: 'local'
 ```
 
-### Ingress Configuration
+### Service
 
-If ingress is enabled, you can customise the host, paths, and TLS settings:
+This chart defaults `service.type` to `LoadBalancer` (unlike the other charts, which default to `ClusterIP`). This is so the BitTorrent peer port can be reached externally, not just the RPC UI. If your cluster doesn't have a `LoadBalancer` provider (e.g. MetalLB, a cloud LB), change it to `NodePort` or `ClusterIP`:
+
+```yaml
+service:
+  type: 'NodePort'
+  # externalTrafficPolicy: 'Local'   # optional; preserves client source IP for NodePort/LoadBalancer
+```
+
+### Ingress
+
+Ingress is disabled by default and typically not needed since the RPC UI is exposed through the LoadBalancer Service. If you want ingress for the UI, enable it and set host/TLS:
 
 ```yaml
 ingress:
   enabled: true
+  host: 'example.com'
+  tls:
+    # Your TLS settings...
 ```
 
 ### VPN Sidecar
@@ -151,7 +165,7 @@ helm upgrade transmission media-servarr/transmission -f myvalues.yaml
 To uninstall/delete the `transmission` deployment:
 
 ```bash
-helm delete transmission
+helm uninstall transmission
 ```
 
 ## Support


### PR DESCRIPTION
## Description

Rewrites the root README to be more informative and easier to scan for both humans and AI agents that recommend tooling. Replaces the bare list of chart links with:

- A per-chart table with one-line descriptions of each application
- A Prerequisites section (k8s, Helm, optional Prometheus Operator)
- Quick-start commands (add repo, search, install, upgrade)
- A "Base Chart Features" summary of what the shared `media-servarr-base` library provides
- A configuration reference covering every major value block (secrets, config, volumes/PVCs, ingress, metrics, service, service account, pod scheduling)
- A pointer to `values.schema.json` and the YAML LSP modeline for editor-time validation

No functional changes — README only.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Checklist

- [ ] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [ ] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [x] My changes are tested and proven to work.
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Testing

Rendered the README locally to confirm markdown formatting (tables, code blocks, TOC links). No chart or template changes, so no `helm lint`/`helm template` verification needed.

## Additional Information

Unticked checklist items (chart version, values changes) are not applicable to a docs-only PR.