### PR TITLE
Auto-merge minor/patch app version updates

### DIFF
--- a/.github/workflows/auto-approve-merge.yaml
+++ b/.github/workflows/auto-approve-merge.yaml
@@ -1,0 +1,98 @@
+name: 'Auto-approve and auto-merge app version updates'
+
+# Approves PRs opened by the auto-update workflow, and (for patch or
+# minor chart bumps) enables auto-merge so they merge once CI is green.
+# Major bumps are approved but require manual merge, so a human can
+# review the upstream release notes for breaking changes.
+#
+# Requires a repo secret named `AUTO_APPROVE_TOKEN`: a fine-grained PAT
+# (or GitHub App installation token) owned by a *different* account than
+# `github-actions[bot]`, with `pull-requests: write` and `contents: write`
+# on this repo. GitHub blocks a bot from approving its own PRs, which is
+# why the default GITHUB_TOKEN can't be used here.
+
+on:
+  pull_request_target:
+    types: ['opened', 'reopened', 'synchronize']
+
+permissions:
+  contents: 'read'
+  pull-requests: 'read'
+
+jobs:
+  approve-and-merge:
+    name: 'Approve and auto-merge'
+    runs-on: 'ubuntu-latest'
+    if: |
+      github.event.pull_request.user.login == 'github-actions[bot]' &&
+      startsWith(github.event.pull_request.title, '⭐️ New App Version:')
+    steps:
+      - name: 'Checkout PR head'
+        uses: 'actions/checkout@v4'
+        with:
+          ref: '${{ github.event.pull_request.head.sha }}'
+          fetch-depth: 0
+
+      - name: 'Determine chart version bump'
+        id: 'bump'
+        run: |
+          # Extract chart name from the PR title:
+          #   "⭐️ New App Version: Update <chart>"
+          chart="$(echo "${{ github.event.pull_request.title }}" | sed -E 's/^⭐️ New App Version: Update //')"
+          chart_file="charts/${chart}/Chart.yaml"
+
+          if [[ ! -f "$chart_file" ]]; then
+            echo "Chart file not found: $chart_file" >&2
+            exit 1
+          fi
+
+          # Fetch the base branch so we can diff versions
+          git fetch origin '${{ github.event.pull_request.base.ref }}' --depth=1
+
+          old_version="$(git show 'origin/${{ github.event.pull_request.base.ref }}:'"$chart_file" | awk '/^version:/ {print $2}')"
+          new_version="$(awk '/^version:/ {print $2}' "$chart_file")"
+
+          IFS='.' read -r old_major old_minor old_patch <<< "$old_version"
+          IFS='.' read -r new_major new_minor new_patch <<< "$new_version"
+
+          if [[ "$new_major" -gt "$old_major" ]]; then
+            bump='major'
+          elif [[ "$new_minor" -gt "$old_minor" ]]; then
+            bump='minor'
+          elif [[ "$new_patch" -gt "$old_patch" ]]; then
+            bump='patch'
+          else
+            bump='none'
+          fi
+
+          echo "Chart '$chart': $old_version -> $new_version ($bump)"
+
+          {
+            echo "chart=$chart"
+            echo "old=$old_version"
+            echo "new=$new_version"
+            echo "bump=$bump"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: 'Approve PR'
+        uses: 'hmarr/auto-approve-action@v4'
+        with:
+          github-token: '${{ secrets.AUTO_APPROVE_TOKEN }}'
+          review-message: |
+            Automated approval — ${{ steps.bump.outputs.chart }} ${{ steps.bump.outputs.old }} → ${{ steps.bump.outputs.new }} (${{ steps.bump.outputs.bump }} bump).
+
+      - name: 'Enable auto-merge (patch or minor only)'
+        if: steps.bump.outputs.bump == 'patch' || steps.bump.outputs.bump == 'minor'
+        env:
+          GH_TOKEN: '${{ secrets.AUTO_APPROVE_TOKEN }}'
+        run: |
+          gh pr merge --auto --squash '${{ github.event.pull_request.number }}'
+          echo "Auto-merge enabled — will merge once required checks pass."
+
+      - name: 'Note: manual merge required (major bump)'
+        if: steps.bump.outputs.bump == 'major'
+        env:
+          GH_TOKEN: '${{ secrets.AUTO_APPROVE_TOKEN }}'
+        run: |
+          gh pr comment '${{ github.event.pull_request.number }}' \
+            --body 'Approved automatically, but this is a **major** bump (${{ steps.bump.outputs.old }} → ${{ steps.bump.outputs.new }}). Auto-merge is disabled — please review upstream release notes and merge manually.'

--- a/.github/workflows/auto-approve-merge.yaml
+++ b/.github/workflows/auto-approve-merge.yaml
@@ -1,27 +1,25 @@
-name: 'Auto-approve and auto-merge app version updates'
+name: 'Auto-merge app version updates'
 
-# Approves PRs opened by the auto-update workflow, and (for patch or
-# minor chart bumps) enables auto-merge so they merge once CI is green.
-# Major bumps are approved but require manual merge, so a human can
-# review the upstream release notes for breaking changes.
+# Enables auto-merge on PRs opened by the nightly auto-update workflow
+# for patch and minor chart bumps. Major bumps get a comment flagging
+# that a human should review upstream release notes before merging.
 #
-# Requires a repo secret named `AUTO_APPROVE_TOKEN`: a fine-grained PAT
-# (or GitHub App installation token) owned by a *different* account than
-# `github-actions[bot]`, with `pull-requests: write` and `contents: write`
-# on this repo. GitHub blocks a bot from approving its own PRs, which is
-# why the default GITHUB_TOKEN can't be used here.
+# Uses the default GITHUB_TOKEN — no PAT required. Main's branch
+# protection doesn't require an approving review, only that lint-helm
+# and lint-shell pass, so auto-merge (`gh pr merge --auto --squash`)
+# will fire the moment those checks go green.
 
 on:
   pull_request_target:
     types: ['opened', 'reopened', 'synchronize']
 
 permissions:
-  contents: 'read'
-  pull-requests: 'read'
+  contents: 'write'
+  pull-requests: 'write'
 
 jobs:
-  approve-and-merge:
-    name: 'Approve and auto-merge'
+  auto-merge:
+    name: 'Enable auto-merge (patch/minor only)'
     runs-on: 'ubuntu-latest'
     if: |
       github.event.pull_request.user.login == 'github-actions[bot]' &&
@@ -74,25 +72,18 @@ jobs:
             echo "bump=$bump"
           } >> "$GITHUB_OUTPUT"
 
-      - name: 'Approve PR'
-        uses: 'hmarr/auto-approve-action@v4'
-        with:
-          github-token: '${{ secrets.AUTO_APPROVE_TOKEN }}'
-          review-message: |
-            Automated approval — ${{ steps.bump.outputs.chart }} ${{ steps.bump.outputs.old }} → ${{ steps.bump.outputs.new }} (${{ steps.bump.outputs.bump }} bump).
-
       - name: 'Enable auto-merge (patch or minor only)'
         if: steps.bump.outputs.bump == 'patch' || steps.bump.outputs.bump == 'minor'
         env:
-          GH_TOKEN: '${{ secrets.AUTO_APPROVE_TOKEN }}'
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           gh pr merge --auto --squash '${{ github.event.pull_request.number }}'
-          echo "Auto-merge enabled — will merge once required checks pass."
+          echo "Auto-merge enabled — will merge once lint-helm and lint-shell pass."
 
       - name: 'Note: manual merge required (major bump)'
         if: steps.bump.outputs.bump == 'major'
         env:
-          GH_TOKEN: '${{ secrets.AUTO_APPROVE_TOKEN }}'
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'
         run: |
           gh pr comment '${{ github.event.pull_request.number }}' \
-            --body 'Approved automatically, but this is a **major** bump (${{ steps.bump.outputs.old }} → ${{ steps.bump.outputs.new }}). Auto-merge is disabled — please review upstream release notes and merge manually.'
+            --body 'This is a **major** bump (${{ steps.bump.outputs.old }} → ${{ steps.bump.outputs.new }}). Auto-merge is disabled — please review upstream release notes and merge manually.'


### PR DESCRIPTION
## Description

Adds `.github/workflows/auto-approve-merge.yaml` which reacts to the nightly `⭐️ New App Version:` PRs from the existing `auto-update.yaml` workflow.

**Behaviour**

- Filters to PRs authored by `github-actions[bot]` with the `⭐️ New App Version:` title prefix.
- Checks out the PR head, diffs the chart `version:` against `main`, and classifies the bump as major / minor / patch / none.
- **Enables auto-merge (squash) for patch and minor bumps** — GitHub then merges once `lint-helm` and `lint-shell` go green.
- **Major bumps** get a comment on the PR flagging that a human should review upstream release notes before merging. No auto-merge.

Lint checks already run on bot PRs automatically, and main's branch protection doesn't require an approving review (only the two lint jobs), so the workflow only needs to enable auto-merge — no explicit approval step or PAT is required. Uses the default `GITHUB_TOKEN`.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [ ] I have updated the chart version in `Chart.yaml` according to [semantic versioning](https://semver.org/).
- [ ] I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.
- [ ] My changes are tested and proven to work.
- [ ] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Setup required before this workflow will work

Just one thing:

1. **Enable "Allow auto-merge"** in Settings → General → Pull Requests.

That's it — no secrets, no PAT, no branch-protection changes.

## Testing

Not yet verified against a live bot PR. Once merged and "Allow auto-merge" is enabled, the next nightly run of `auto-update.yaml` (2am UTC) will exercise it — or trigger `auto-update.yaml` manually from the Actions tab to test sooner.

## Additional Information

- Note: `lint-helm` is currently failing on bot PRs due to an unrelated chart-template issue (`secret.yaml` doesn't guard against empty `value` with no `ref`, so `b64enc` errors). That's a separate fix; the auto-merge workflow will only merge PRs where lint is green.
- Non-applicable checklist items (chart version, values changes, tests, docs) don't apply to a CI-only PR.