### PR TITLE
Fix auto-update PR checks and auto-merge non-major bumps

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -57,16 +57,11 @@ jobs:
 
       - name: 'Update AppVersion and ChartVersion'
         run: |
-          # Capture the current appVersion before the update script rewrites it,
-          # so we can classify the bump type after.
-          OLD_APP_VERSION=$(awk '/^appVersion:/ {print $2}' "./charts/${{ matrix.name }}/Chart.yaml")
-          echo "OLD_APP_VERSION=${OLD_APP_VERSION}" >> "$GITHUB_ENV"
-
           # Set global script settings
           export ALLOW_PRERELEASE='${{ matrix.allow_prerelease }}'
           export STRIP_VERSION_PREFIX='${{ matrix.strip_prefix }}'
 
-          # Call main script to fetch newest app version
+          # The script writes VERSION_TYPE (major|minor|patch) to $GITHUB_ENV.
           ./scripts/update_appversion.sh \
             '${{ matrix.name }}' \
             '${{ matrix.repo }}' \
@@ -95,29 +90,10 @@ jobs:
           COMMIT_MSG="New app version found for ${{ matrix.name }}"
           echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
           echo "COMMIT_MSG=$BRANCH_NAME" >> "$GITHUB_ENV"
-          echo "NEW_APP_VERSION=$app_version" >> "$GITHUB_ENV"
 
-      - name: 'Classify version bump'
-        if: env.CHANGES_FOUND == 'true'
-        run: |
-          # Extract the semver core (major.minor.patch) from each version, ignoring
-          # any prefix (e.g. 'v') or build metadata (e.g. '-ls123').
-          old=$(echo "$OLD_APP_VERSION" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
-          new=$(echo "$NEW_APP_VERSION" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
-
-          IFS='.' read -r old_major old_minor _ <<< "$old"
-          IFS='.' read -r new_major new_minor _ <<< "$new"
-
-          if [[ "$new_major" -gt "$old_major" ]]; then
-            BUMP_TYPE=major
-          elif [[ "$new_minor" -gt "$old_minor" ]]; then
-            BUMP_TYPE=minor
-          else
-            BUMP_TYPE=patch
+          if [[ "$VERSION_TYPE" != "major" ]]; then
+            echo "AUTOMERGE=true" >> "$GITHUB_ENV"
           fi
-
-          echo "Bump: $old -> $new ($BUMP_TYPE)"
-          echo "BUMP_TYPE=$BUMP_TYPE" >> "$GITHUB_ENV"
 
       - name: 'Create Pull Request'
         id: create-pr
@@ -131,8 +107,8 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
           base: ${{ github.event.repository.default_branch }}
 
-      - name: 'Enable auto-merge for minor/patch bumps'
-        if: env.CHANGES_FOUND == 'true' && env.BUMP_TYPE != 'major' && steps.create-pr.outputs.pull-request-number
+      - name: 'Enable auto-merge for non-major bumps'
+        if: env.AUTOMERGE == 'true' && steps.create-pr.outputs.pull-request-number
         env:
           GH_TOKEN: ${{ secrets.AUTO_UPDATE_PAT }}
           PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}

--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -53,6 +53,7 @@ jobs:
       - uses: 'actions/checkout@v4'
         with:
           fetch-depth: 0
+          token: ${{ secrets.AUTO_UPDATE_PAT }}
 
       - name: 'Update AppVersion and ChartVersion'
         run: |
@@ -94,6 +95,7 @@ jobs:
         if: env.CHANGES_FOUND == 'true'
         uses: 'peter-evans/create-pull-request@v7'
         with:
+          token: ${{ secrets.AUTO_UPDATE_PAT }}
           commit-message: ${{ env.COMMIT_MSG }}
           title: "⭐️ New App Version: Update ${{ matrix.name }}"
           body: 'Automated Workflow. New App Version found for Chart'

--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -57,6 +57,11 @@ jobs:
 
       - name: 'Update AppVersion and ChartVersion'
         run: |
+          # Capture the current appVersion before the update script rewrites it,
+          # so we can classify the bump type after.
+          OLD_APP_VERSION=$(awk '/^appVersion:/ {print $2}' "./charts/${{ matrix.name }}/Chart.yaml")
+          echo "OLD_APP_VERSION=${OLD_APP_VERSION}" >> "$GITHUB_ENV"
+
           # Set global script settings
           export ALLOW_PRERELEASE='${{ matrix.allow_prerelease }}'
           export STRIP_VERSION_PREFIX='${{ matrix.strip_prefix }}'
@@ -90,8 +95,32 @@ jobs:
           COMMIT_MSG="New app version found for ${{ matrix.name }}"
           echo "BRANCH_NAME=$BRANCH_NAME" >> "$GITHUB_ENV"
           echo "COMMIT_MSG=$BRANCH_NAME" >> "$GITHUB_ENV"
+          echo "NEW_APP_VERSION=$app_version" >> "$GITHUB_ENV"
+
+      - name: 'Classify version bump'
+        if: env.CHANGES_FOUND == 'true'
+        run: |
+          # Extract the semver core (major.minor.patch) from each version, ignoring
+          # any prefix (e.g. 'v') or build metadata (e.g. '-ls123').
+          old=$(echo "$OLD_APP_VERSION" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+          new=$(echo "$NEW_APP_VERSION" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1)
+
+          IFS='.' read -r old_major old_minor _ <<< "$old"
+          IFS='.' read -r new_major new_minor _ <<< "$new"
+
+          if [[ "$new_major" -gt "$old_major" ]]; then
+            BUMP_TYPE=major
+          elif [[ "$new_minor" -gt "$old_minor" ]]; then
+            BUMP_TYPE=minor
+          else
+            BUMP_TYPE=patch
+          fi
+
+          echo "Bump: $old -> $new ($BUMP_TYPE)"
+          echo "BUMP_TYPE=$BUMP_TYPE" >> "$GITHUB_ENV"
 
       - name: 'Create Pull Request'
+        id: create-pr
         if: env.CHANGES_FOUND == 'true'
         uses: 'peter-evans/create-pull-request@v7'
         with:
@@ -101,3 +130,10 @@ jobs:
           body: 'Automated Workflow. New App Version found for Chart'
           branch: ${{ env.BRANCH_NAME }}
           base: ${{ github.event.repository.default_branch }}
+
+      - name: 'Enable auto-merge for minor/patch bumps'
+        if: env.CHANGES_FOUND == 'true' && env.BUMP_TYPE != 'major' && steps.create-pr.outputs.pull-request-number
+        env:
+          GH_TOKEN: ${{ secrets.AUTO_UPDATE_PAT }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --auto --squash "$PR_NUMBER"

--- a/scripts/update_appversion.sh
+++ b/scripts/update_appversion.sh
@@ -150,43 +150,58 @@ update_appversion() {
   echo "Updated '${chart_file}' appVersion to '${latest_version}'"
 }
 
-# Increments the Helm chart's 'version' based on the difference between old and new appVersion.
+# Classifies the semver bump between two versions.
+# Arguments:
+#   version_old: The previous version.
+#   version_new: The new version.
+# Outputs:
+#   Writes one of "major", "minor", or "patch" to stdout.
+get_version_type() {
+  local old_semver
+  local new_semver
+
+  old_semver=$(echo "$1" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+  new_semver=$(echo "$2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+
+  IFS='.' read -r old_major old_minor _ <<< "$old_semver"
+  IFS='.' read -r new_major new_minor _ <<< "$new_semver"
+
+  if [[ "$new_major" -gt "$old_major" ]]; then
+    echo "major"
+  elif [[ "$new_minor" -gt "$old_minor" ]]; then
+    echo "minor"
+  else
+    # patch, build metadata, or no-op — treat all as patch for chart bumping
+    echo "patch"
+  fi
+}
+
+# Increments the Helm chart's 'version' based on the type of appVersion bump.
 # Arguments:
 #   chart_file: The path to the Chart.yaml file.
-#   appversion_old: The old appVersion.
-#   appversion_new: The new appVersion.
-# Outputs:
-#   Writes the new chart version to stdout.
+#   version_type: One of "major", "minor", or "patch".
 update_chartversion() {
   local chart_file="$1"
-  local appversion_old
-  local appversion_new
+  local version_type="$2"
   local chart_version
 
-  # Start by identifying what type of update the appVersion was
-  appversion_old=$(echo "$2" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-  appversion_new=$(echo "$3" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
-
-  IFS='.' read -r major_old minor_old patch_old <<< "$appversion_old"
-  IFS='.' read -r major_new minor_new patch_new <<< "$appversion_new"
-
-  # Now let's update the chart_version with the same type of upgrade
   chart_version=$(grep -E '^version:' "$chart_file" | sed -E 's/version: *//')
   IFS='.' read -r chart_major chart_minor chart_patch <<< "$chart_version"
 
-  if [[ "$major_new" -gt "$major_old" ]]; then
-    chart_major=$(expr "$chart_major" + 1)
-    chart_minor=0
-    chart_patch=0
-  elif [[ "$minor_new" -gt "$minor_old" ]]; then
-    chart_minor=$(expr "$chart_minor" + 1)
-    chart_patch=0
-  elif [[ "$patch_new" -gt "$patch_old" ]]; then
-    chart_patch=$(expr "$chart_patch" + 1)
-  else
-    ## This could be a build update, so we'll assume patch also
-    chart_patch=$(expr "$chart_patch" + 1)
-  fi
+  case "$version_type" in
+    major)
+      chart_major=$(expr "$chart_major" + 1)
+      chart_minor=0
+      chart_patch=0
+      ;;
+    minor)
+      chart_minor=$(expr "$chart_minor" + 1)
+      chart_patch=0
+      ;;
+    *)
+      chart_patch=$(expr "$chart_patch" + 1)
+      ;;
+  esac
 
   new_chart_version="${chart_major}.${chart_minor}.${chart_patch}"
 
@@ -234,9 +249,17 @@ main() {
 
   echo "Current chart uses appVersion '${current_version}'"
 
+  version_type=$(get_version_type "${current_version}" "${latest_version}")
+  echo "Version bump type: '${version_type}'"
+
+  # Expose the classification to GitHub Actions when running in that context.
+  if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "VERSION_TYPE=${version_type}" >> "${GITHUB_ENV}"
+  fi
+
   update_appversion "${chart_file}" "${latest_version}"
 
-  update_chartversion "${chart_file}" "${current_version}" "${latest_version}"
+  update_chartversion "${chart_file}" "${version_type}"
 }
 
 main "$@"


### PR DESCRIPTION
## Description

Two changes to `.github/workflows/auto-update.yaml` (plus a small refactor in `scripts/update_appversion.sh`) that fix a long-standing rough edge in the nightly app-version updater.

**1. Lint runs without manual approval.** Auto-update PRs are opened by `github-actions[bot]` via the default `GITHUB_TOKEN`. GitHub deliberately blocks `pull_request` workflows on PRs created that way, which is why every `lint-shell` / `lint-helm` run on those PRs sits in "waiting for approval". Switching `actions/checkout` and `peter-evans/create-pull-request` to a PAT (`AUTO_UPDATE_PAT`) means PRs are authored by a real user and their checks run automatically.

**2. Auto-merge non-major app-version bumps.** `scripts/update_appversion.sh` already classified each update as major/minor/patch internally to decide how to bump the chart version — this PR factors that into a `get_version_type` helper and exports the result to `$GITHUB_ENV` as `VERSION_TYPE`. The workflow sets `AUTOMERGE=true` when `VERSION_TYPE != major` and calls `gh pr merge --auto --squash` on the resulting PR. Major bumps still land as normal PRs for manual review.

Auto-merge relies on GitHub's native mechanism, which only merges once the PR is mergeable per branch protection — so lint failures block the merge **provided** the checks are marked required on `main`.

### Setup required after merge

- **Repo secret** `AUTO_UPDATE_PAT` — fine-grained PAT scoped to this repo with `Contents: read/write` and `Pull requests: read/write`.
- **Settings → Pull Requests → "Allow auto-merge"** must be enabled.
- **Branch protection on `main`** should mark `lint-shell` and `lint-helm` as required status checks, otherwise auto-merge would fire without waiting for lint.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

_This PR modifies CI only; the chart-facing checklist items are not applicable and are marked N/A._

- [ ] ~~I have updated the chart version in `Chart.yaml` according to semantic versioning.~~ N/A — no chart changes.
- [ ] ~~I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.~~ N/A — no chart changes.
- [x] My changes are tested and proven to work.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] ~~I have made corresponding changes to the documentation.~~ N/A — no user-facing docs affected.
- [x] My changes generate no new warnings.

## Testing

- Smoke-tested `get_version_type` locally against the representative version-pair matrix below — all pass:
  - `1.2.3 -> 2.0.0` → `major`
  - `1.2.3 -> 1.3.0` → `minor`
  - `1.2.3 -> 1.2.4` → `patch`
  - `1.2.3 -> 1.2.3` → `patch` (no-op)
  - `v1.2.3 -> v1.3.0` → `minor` (prefixed)
  - `5.0.0-ls123 -> 5.1.0-ls124` → `minor` (linuxserver build metadata)
- The end-to-end workflow behaviour (PAT-triggered checks, auto-merge) can only be verified after merge, once the repo secret and branch-protection settings above are in place.

## Additional Information

The one visible side-effect: auto-update PRs will now show as authored by whichever user owns `AUTO_UPDATE_PAT`, not `github-actions[bot]`. That's the mechanism that unblocks the check triggers — there isn't a way around it short of switching to a GitHub App.