### PR TITLE
Fix helm lint crash on unset external-secret ref

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: 'v2'
 name: 'media-servarr-base'
 description: 'Base chart for media-servarr charts'
 type: 'application'
-version: 0.15.0
+version: 0.15.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'bazarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.0
+version: 0.15.1
 appVersion: 1.6.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/cleanuparr/Chart.yaml
+++ b/charts/cleanuparr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'whisparr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.0
+version: 0.15.1
 appVersion: 2.9.16
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/cleanuparr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/flaresolverr/Chart.yaml
+++ b/charts/flaresolverr/Chart.yaml
@@ -9,12 +9,12 @@ keywords:
   - 'bypass'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.0
+version: 0.15.1
 appVersion: v3.5.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/flaresolverr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -7,12 +7,12 @@ keywords:
   - 'homarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.46.0
+version: 0.46.1
 appVersion: v1.71.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/homarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -15,12 +15,12 @@ keywords:
   - 'jellyfin'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.0
+version: 0.14.1
 appVersion: 10.11.11
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -11,12 +11,12 @@ keywords:
   - 'lidarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.5.0
+version: 1.5.1
 appVersion: 3.1.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/profilarr/Chart.yaml
+++ b/charts/profilarr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'profilarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.3.0
+version: 0.3.1
 appVersion: v1.1.5
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/profilarr/icon.png'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/profilarr'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'prowlarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.25.0
+version: 0.25.1
 appVersion: 2.4.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'radarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.7.0
+version: 1.7.1
 appVersion: 6.2.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -12,13 +12,13 @@ keywords:
   - 'readarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.0
+version: 0.15.1
 appVersion: 0.4.19-nightly
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png'
 deprecated: true
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -8,12 +8,12 @@ keywords:
   - 'sabnzbd'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.2.0
+version: 1.2.1
 appVersion: 5.0.4
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'sonarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.0
+version: 0.14.1
 appVersion: 4.0.19
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/tinymediamanager/Chart.yaml
+++ b/charts/tinymediamanager/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'tinymediamanager'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.3.0
+version: 1.3.1
 appVersion: 5.3.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/tinymediamanager'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'usenet'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.0
+version: 0.15.1
 appVersion: 4.1.3
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/transmission/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.0
+    version: 0.15.1
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/templates/secret.yaml
+++ b/templates/secret.yaml
@@ -14,7 +14,7 @@ data:
 {{- range .Values.secrets }}
   {{- if .value }}
   {{ .name }}: '{{ .value | b64enc }}'
-  {{- else }}
+  {{- else if .ref }}
   {{ .name }}: '{{ .ref | b64enc }}'
   {{- end }}
 {{- end }}


### PR DESCRIPTION
## Description

Fixes a `helm lint` failure that has been breaking every auto-update PR (e.g. #465) since 2025-10-04.

### Root cause

Commit 78fe75e ("Add external secret support") added an `else` branch to `templates/secret.yaml` that b64-encodes `.ref` when `.value` is falsy:

\`\`\`gotemplate
{{- range .Values.secrets }}
  {{- if .value }}
  {{ .name }}: '{{ .value | b64enc }}'
  {{- else }}
  {{ .name }}: '{{ .ref | b64enc }}'
  {{- end }}
{{- end }}
\`\`\`

Every consumer chart's `values.yaml` ships with:

\`\`\`yaml
secrets:
  - name: 'apiKey'
    value: ''
\`\`\`

`{{ if .value }}` is falsy on empty string → the `else` branch runs → `b64enc` is invoked on nil `.ref` → `invalid value; expected string`. Locally reproducible with `helm lint charts/radarr` on main.

Users installing published charts are unaffected because those still bundle the pre-regression 0.13.0 base chart. Only CI (and anyone consuming the local base) hit it — which is why every auto-update PR since October has had a red `lint-helm`.

### Fix

Only render the ref line when `.ref` is set. When both `value` and `ref` are absent, the entry is skipped entirely.

Base chart bumped 0.15.0 → 0.15.1 (via `scripts/update_base.sh patch`); every consumer patch-bumped and its `media-servarr-base` dependency updated to 0.15.1.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Non-breaking change which adds functionality
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Checklist

- [x] I have updated the chart version in `Chart.yaml` according to semantic versioning.
- [ ] ~~I have included any new or changed values in the `values.yaml` file and documented them in the README if applicable.~~ N/A — no values or interface changes.
- [x] My changes are tested and proven to work.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] ~~I have made corresponding changes to the documentation.~~ N/A — no user-facing docs affected.
- [x] My changes generate no new warnings.

## Testing

- Reproduced the failure locally on `main` with `helm lint charts/radarr` — same error as CI.
- After the fix, ran `helm dependency update` + `helm lint` on `charts/radarr` and `charts/homarr` — both green.
- Rendered the Secret manually with `helm template` to confirm behaviour:
  - `value: 'abc'` → Secret with `apiKey: YWJjMTIz` (correct b64).
  - `value: ''` (default) → Secret still emitted with an empty `data:` block (matches pre-regression behaviour, which emitted an empty b64 string).
  - `ref: 'my-secret'` only → no data key rendered; `deployment.yaml` picks up the external secret name.

## Additional Information

Once merged, the next scheduled auto-update run should have passing `lint-helm` on its PRs. Combined with PR #469 (auto-update workflow using a PAT and auto-merging non-major bumps), the whole nightly loop should be hands-off for non-major upgrades.