### PR TITLE
Update profilarr to v2.0.9 and bump chart to 1.0.0

### DIFF
--- a/charts/profilarr/Chart.yaml
+++ b/charts/profilarr/Chart.yaml
@@ -10,8 +10,8 @@ keywords:
   - 'profilarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.3.1
-appVersion: v1.1.5
+version: 1.0.0
+appVersion: v2.0.9
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/profilarr/icon.png'
 maintainers:
   - name: 'media-servarr'

--- a/charts/profilarr/README.md
+++ b/charts/profilarr/README.md
@@ -10,8 +10,10 @@ This README covers the basics of customising and installation
 * [Installation](#installation)
 * [Configuration](#configuration)
   * [Application Configuration](#application-configuration)
+  * [Authentication](#authentication)
   * [Volumes](#volumes)
   * [Ingress](#ingress)
+  * [Parser Sidecar (optional)](#parser-sidecar-optional)
   * [Advanced](#advanced)
 * [Upgrading](#upgrading)
 * [Uninstallation](#uninstallation)
@@ -48,6 +50,20 @@ deployment:
       - name: 'TZ'
         value: 'UTC'
 ```
+
+### Authentication
+
+Profilarr v2 supports three auth modes via the `AUTH` env var:
+
+- `on` (default) — password auth managed inside Profilarr.
+- `off` — no auth. Only use on trusted networks or behind a proxy that authenticates for you.
+- `oidc` — OpenID Connect via an external identity provider.
+
+For OIDC, set `AUTH=oidc`, provide the three OIDC vars, and set `ORIGIN` to your public URL. Profilarr expects the redirect URL at `{ORIGIN}/auth/oidc/callback` — most IdPs infer this automatically.
+
+Because `OIDC_CLIENT_SECRET` is sensitive, define it in the chart's `secrets:` block (or point at an existing Kubernetes Secret via `ref`) and bind it in `deployment.container.env` with `valueFrom.secretKeyRef`. Commented examples for both are in the chart's default `values.yaml`.
+
+You can also set `PROFILARR_API_KEY` (min 32 characters) the same way — when set it overrides the stored database key for `X-Api-Key` auth without being persisted to SQLite.
 
 ### Volumes
 
@@ -90,6 +106,25 @@ ingress:
   tls:
     # Your TLS settings...
 ```
+
+### Parser Sidecar (optional)
+
+Custom-format and quality-profile *testing* — the screens where Profilarr checks a release name against your formats or simulates how a profile would score a release — is powered by a separate C# service that mirrors Radarr/Sonarr's own parsing logic. Every other feature (linking databases, building profiles, syncing to your arr instances, upgrade automation, notifications) works without it.
+
+To enable, run the parser as a sidecar in the same Pod, listening on port `5000`:
+
+```yaml
+deployment:
+  sideCarContainers:
+    - name: 'parser'
+      image: 'ghcr.io/dictionarry-hub/profilarr-parser:v2.0.9'
+      ports:
+        - containerPort: 5000
+          name: 'parser'
+          protocol: 'TCP'
+```
+
+Pin the parser tag to the same version as Profilarr — they release together. Because the sidecar shares the Pod network, Profilarr reaches it on `localhost:5000` (its default), so no extra `PARSER_HOST` / `PARSER_PORT` env vars are needed.
 
 ### Advanced
 

--- a/charts/profilarr/values.yaml
+++ b/charts/profilarr/values.yaml
@@ -4,12 +4,26 @@ nameOverride: ''
 fullnameOverride: ''
 
 #
+# Secrets to create
+#
+# Profilarr uses env vars (not a config file), so unlike the arr charts the base
+# chart cannot auto-inject these — a matching valueFrom.secretKeyRef entry in
+# deployment.container.env below is also needed. See the commented
+# PROFILARR_API_KEY example there.
+secrets: []
+  # # PROFILARR_API_KEY must be at least 32 characters. When set it overrides
+  # # the stored database key without being persisted to SQLite. Optional.
+  # - name: 'PROFILARR_API_KEY'
+  #   value: 'replace-with-a-random-string-of-at-least-32-chars'
+  #   # ref: 'my-existing-secret' # alternatively point at an existing K8s Secret
+
+#
 # Application Config
 #
 application:
   # Main application web UI port
   port: 6868
-  # Profilarr is best exposed at root on a dedicated host
+  # Profilarr does not support urlBase
   urlBase: ''
 
 #
@@ -22,12 +36,28 @@ deployment:
       repository: 'ghcr.io/dictionarry-hub/profilarr'
 
     env:
+      - name: 'PUID'
+        value: '1000'
+      - name: 'PGID'
+        value: '1000'
       - name: 'TZ'
         value: 'UTC'
       # Set AUTH to 'off' or 'oidc' to use a different authentication mode.
       # Consult the Profilarr docs for the required configuration when not using the default.
       - name: 'AUTH'
         value: 'on'
+      # # Required when Profilarr sits behind a reverse proxy (and mandatory
+      # # for OIDC). Set to the public URL that reaches the app.
+      # - name: 'ORIGIN'
+      #   value: 'https://profilarr.example.com'
+      # # Uncomment together with an entry in `secrets:` above to pass the API
+      # # key to the container. `name` must match the Secret created by the
+      # # chart: `<release-name>-profilarr` (or your `fullnameOverride`).
+      # - name: 'PROFILARR_API_KEY'
+      #   valueFrom:
+      #     secretKeyRef:
+      #       name: 'release-name-profilarr'
+      #       key: 'PROFILARR_API_KEY'
 
     volumeMounts:
       - name: 'config'

--- a/charts/profilarr/values.yaml
+++ b/charts/profilarr/values.yaml
@@ -19,7 +19,7 @@ application:
 deployment:
   container:
     image:
-      repository: 'santiagosayshey/profilarr'
+      repository: 'ghcr.io/dictionarry-hub/profilarr'
 
     env:
       - name: 'TZ'

--- a/charts/profilarr/values.yaml
+++ b/charts/profilarr/values.yaml
@@ -16,6 +16,12 @@ secrets: []
   # - name: 'PROFILARR_API_KEY'
   #   value: 'replace-with-a-random-string-of-at-least-32-chars'
   #   # ref: 'my-existing-secret' # alternatively point at an existing K8s Secret
+  #
+  # # OIDC client secret. Required when AUTH=oidc. Keep this out of values.yaml
+  # # in production and use `ref` to point at a pre-existing Secret.
+  # - name: 'OIDC_CLIENT_SECRET'
+  #   value: ''
+  #   # ref: 'my-oidc-secret'
 
 #
 # Application Config
@@ -58,6 +64,19 @@ deployment:
       #     secretKeyRef:
       #       name: 'release-name-profilarr'
       #       key: 'PROFILARR_API_KEY'
+      #
+      # # OIDC authentication. Set AUTH=oidc above, provide the three vars
+      # # below, and ensure ORIGIN is set. Profilarr expects the redirect URL
+      # # at {ORIGIN}/auth/oidc/callback — most IdPs infer this automatically.
+      # - name: 'OIDC_CLIENT_ID'
+      #   value: 'your-client-id'
+      # - name: 'OIDC_DISCOVERY_URL'
+      #   value: 'https://your-idp.example.com/.well-known/openid-configuration'
+      # - name: 'OIDC_CLIENT_SECRET'
+      #   valueFrom:
+      #     secretKeyRef:
+      #       name: 'release-name-profilarr'
+      #       key: 'OIDC_CLIENT_SECRET'
 
     volumeMounts:
       - name: 'config'

--- a/charts/profilarr/values.yaml
+++ b/charts/profilarr/values.yaml
@@ -82,6 +82,18 @@ deployment:
       - name: 'config'
         mountPath: '/config'
 
+  # # Optional: run the profilarr-parser sidecar to enable custom-format and
+  # # quality-profile testing in the UI. Pin the tag to match profilarr's
+  # # appVersion — they release together. Profilarr connects to localhost:5000
+  # # by default (shared Pod network), so no extra env vars are needed.
+  # sideCarContainers:
+  #   - name: 'parser'
+  #     image: 'ghcr.io/dictionarry-hub/profilarr-parser:v2.0.9'
+  #     ports:
+  #       - containerPort: 5000
+  #         name: 'parser'
+  #         protocol: 'TCP'
+
   volumes:
     config:
       persistentVolumeClaim:


### PR DESCRIPTION
## Description

Rolls the profilarr chart forward to app version v2.0.9 and bumps the chart itself to 1.0.0 to mark the appVersion major jump. Along the way, fleshes out the values.yaml with v2 defaults, commented examples for the common optional features, and adds matching README sections.

### Chart update

- \`appVersion: v1.1.5 -> v2.0.9\`
- \`version: 0.3.1 -> 1.0.0\`
- \`deployment.container.image.repository: santiagosayshey/profilarr -> ghcr.io/dictionarry-hub/profilarr\` — the official image moved from Docker Hub to GHCR at v2; the old image is stale.

### v2 recommended defaults (uncommented)

- \`PUID: 1000\` / \`PGID: 1000\` — matches how the arr charts do it and follows the pattern in profilarr's own docs.

### Commented examples in values.yaml

- \`secrets:\` block — \`PROFILARR_API_KEY\` and \`OIDC_CLIENT_SECRET\`, with both \`value:\` and \`ref:\` forms shown.
- \`deployment.container.env\`:
  - \`ORIGIN\` — needed behind a reverse proxy, mandatory for OIDC.
  - \`PROFILARR_API_KEY\` — via \`valueFrom.secretKeyRef\`. Manual wiring is needed because Profilarr uses env vars (not a config file), so the base chart's automatic secret injection (which is tied to \`application.config\`) doesn't fit.
  - \`OIDC_CLIENT_ID\`, \`OIDC_DISCOVERY_URL\`, \`OIDC_CLIENT_SECRET\` — full OIDC block, with \`CLIENT_SECRET\` bound via \`secretKeyRef\`.
- \`deployment.sideCarContainers\` — \`profilarr-parser\` sidecar for CF/QP testing, pinned to the matching profilarr version and listening on port 5000.

### Documentation

Two new sections in the profilarr chart README:

- **Authentication** — the three \`AUTH\` modes, OIDC setup (env vars, callback URL, secret plumbing), and how to use \`PROFILARR_API_KEY\`.
- **Parser Sidecar (optional)** — what the parser is, when it's needed (CF/QP testing only, everything else works without it), and the minimal sidecar spec.

### Users upgrading from v1

v2 is [not compatible with v1 data](https://github.com/Dictionarry-Hub/profilarr/releases/tag/v2.0.0) — anyone upgrading in place should read the v2 release notes and be prepared to reconfigure. Highlights of v2: multiple databases, built-in upgrade automation, new customisation layer (no more git three-way merges), OIDC support, overhauled UI.

### Deferred to a follow-up

- The \`profilarr\` matrix entry in \`.github/workflows/auto-update.yaml\` still points at \`santiagosayshey/profilarr\` on Docker Hub. That's why the auto-updater never picked up v2. It should be switched to \`Dictionarry-Hub/profilarr\` on GHCR — happy to raise a separate PR for that.
- First-class parser support (a \`parser.enabled\` flag that wires the sidecar automatically) — out of scope; the commented example is enough for now.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Non-breaking change which adds functionality
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

Breaking for consumers upgrading in place — v2 app data isn't compatible with v1.

## Checklist

- [x] I have updated the chart version in \`Chart.yaml\` according to semantic versioning.
- [x] I have included any new or changed values in the \`values.yaml\` file and documented them in the README if applicable.
- [x] My changes are tested and proven to work.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Testing

- \`helm dependency update charts/profilarr\` — clean.
- \`helm lint charts/profilarr\` — passes.
- \`check-jsonschema\` against both \`values.schema.json\` and the Helm chart schema — pass.
- \`helm template charts/profilarr\` — renders four resources (PVC, Service, Deployment, Ingress) with the new image tag \`ghcr.io/dictionarry-hub/profilarr:v2.0.9\`; \`PUID\`/\`PGID\`/\`TZ\`/\`AUTH\` env vars come through; the sidecar stays commented (only the profilarr container renders).