### PR TITLE
Escape sed metacharacters in secret substitution (fixes #343)

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: 'v2'
 name: 'media-servarr-base'
 description: 'Base chart for media-servarr charts'
 type: 'application'
-version: 0.15.1
+version: 0.15.2
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png?raw=true'

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'bazarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.0
+version: 0.16.1
 appVersion: 1.6.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/cleanuparr/Chart.yaml
+++ b/charts/cleanuparr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'whisparr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.17.0
+version: 0.17.1
 appVersion: 2.10.5
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/cleanuparr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/flaresolverr/Chart.yaml
+++ b/charts/flaresolverr/Chart.yaml
@@ -9,12 +9,12 @@ keywords:
   - 'bypass'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.0
+version: 0.16.1
 appVersion: v3.5.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/flaresolverr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -7,12 +7,12 @@ keywords:
   - 'homarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.51.0
+version: 0.51.1
 appVersion: v1.75.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/homarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -15,12 +15,12 @@ keywords:
   - 'jellyfin'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.0
+version: 0.15.1
 appVersion: 10.11.11
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -11,12 +11,12 @@ keywords:
   - 'lidarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.6.0
+version: 1.6.1
 appVersion: 3.1.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/profilarr/Chart.yaml
+++ b/charts/profilarr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'profilarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 2.1.0
+version: 2.1.1
 appVersion: 2.2.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/profilarr/icon.png?raw=true'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/profilarr'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'prowlarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.27.0
+version: 0.27.1
 appVersion: 2.5.2
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'radarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.9.0
+version: 1.9.1
 appVersion: 6.3.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -12,13 +12,13 @@ keywords:
   - 'readarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.0
+version: 0.16.1
 appVersion: 0.4.19-nightly
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png?raw=true'
 deprecated: true
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -8,12 +8,12 @@ keywords:
   - 'sabnzbd'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.4.0
+version: 1.4.1
 appVersion: 5.1.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'sonarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.0
+version: 0.15.1
 appVersion: 4.0.19
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/tinymediamanager/Chart.yaml
+++ b/charts/tinymediamanager/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'tinymediamanager'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.4.0
+version: 1.4.1
 appVersion: 5.3.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png?raw=true'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/tinymediamanager'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'usenet'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.0
+version: 0.16.1
 appVersion: 4.1.3
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/transmission/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.15.2
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -77,12 +77,17 @@ spec:
             - '-c'
             - |
               #!/bin/sh
-              # Inject secrets in config if set
+              # Inject secrets in config if set.
+              # Secret values are pre-escaped so sed metacharacters (&, /, \)
+              # in the replacement don't break the s/// command. See #343.
               {{- range $config }}
               {{- if gt (len (default list .secrets)) 0 }}
+              {{- range .secrets }}
+              {{ . }}_esc=$(printf '%s' "${{ . }}" | sed -e 's|[&/\]|\\&|g')
+              {{- end }}
               sed \
                 {{- range .secrets }}
-                -e "s/\${{ . }}/${{ . }}/g" \
+                -e "s/\${{ . }}/${{ . }}_esc/g" \
                 {{- end }}
                 '/config-map/{{ .filename }}' > \
                 '/config-processed/{{ .filename }}'


### PR DESCRIPTION
## Description

Fixes #343: when a chart's `application.config[].secrets` referenced a secret whose value contained `/` (or `&`, or `\`), the `prepare-config` init container crashed with:

```
sed: -e expression #1, char 22: unknown option to 's'
```

Root cause in `templates/deployment.yaml`: the rendered init-container script inlined each secret value into a sed `s/pattern/value/g` command. When the value contained sed metacharacters — `/` (the delimiter), `&` (matched-text back-reference), or `\` (escape) — the command was malformed. The reporter hit this trying to store a WireGuard `Address = 10.0.0.2/16` as a secret.

### Fix

Pre-escape each value in the shell before it lands in the sed replacement, using the standard `sed 's|[&/\]|\\&|g'` idiom. Rendered init-container script now looks like:

```sh
apiKey_esc=$(printf '%s' "$apiKey" | sed -e 's|[&/\]|\\&|g')
sed \
  -e "s/\$apiKey/$apiKey_esc/g" \
  '/config-map/config.xml' > '/config-processed/config.xml'
```

No new dependencies. The change is limited to the `range` block inside the `prepare-config` script in `templates/deployment.yaml`.

### Versions

Base chart `0.15.1 → 0.15.2`; every consumer chart patch-bumped and its `media-servarr-base` dependency version updated to `0.15.2` via `scripts/update_base.sh patch`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Verified locally that `sed 's|[&/\]|\\&|g'` correctly escapes tricky values (`10.0.0.2/16`, values with `&`, `\`, combinations). Removing the escape reproduces the exact `sed: unknown option to 's'` error from the bug report.
- `helm dependency update charts/radarr && helm lint charts/radarr` — passes.
- `helm template charts/radarr` — the `prepare-config` init container renders with the `apiKey_esc=` preamble and the `s/\$apiKey/$apiKey_esc/g` invocation, as designed.

The runtime confirmation (deploying with a `/`-containing secret and confirming the pod starts) still has to happen in a real cluster; happy for @guilfoos to sanity-check on their WireGuard setup once this lands.

Closes #343