### PR TITLE
Fix icon URLs (raw) and bump subchart versions

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -3,4 +3,4 @@ name: 'media-servarr-base'
 description: 'Base chart for media-servarr charts'
 type: 'application'
 version: 0.15.1
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png?raw=true'

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -15,7 +15,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.15.1
 appVersion: 1.6.0
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - 'bazarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: 1.6.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png?raw=true'
 dependencies:

--- a/charts/cleanuparr/Chart.yaml
+++ b/charts/cleanuparr/Chart.yaml
@@ -14,7 +14,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.16.5
 appVersion: 2.10.5
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/cleanuparr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/cleanuparr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/cleanuparr/Chart.yaml
+++ b/charts/cleanuparr/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - 'whisparr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.5
+version: 0.17.0
 appVersion: 2.10.5
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/cleanuparr/icon.png?raw=true'
 dependencies:

--- a/charts/flaresolverr/Chart.yaml
+++ b/charts/flaresolverr/Chart.yaml
@@ -9,7 +9,7 @@ keywords:
   - 'bypass'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: v3.5.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/flaresolverr/icon.png?raw=true'
 dependencies:

--- a/charts/flaresolverr/Chart.yaml
+++ b/charts/flaresolverr/Chart.yaml
@@ -11,7 +11,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.15.1
 appVersion: v3.5.0
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/flaresolverr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/flaresolverr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -7,7 +7,7 @@ keywords:
   - 'homarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.50.0
+version: 0.51.0
 appVersion: v1.75.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/homarr/icon.png?raw=true'
 dependencies:

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -9,7 +9,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.50.0
 appVersion: v1.75.0
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/homarr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/homarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -17,7 +17,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.14.1
 appVersion: 10.11.11
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
   - 'jellyfin'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.1
+version: 0.15.0
 appVersion: 10.11.11
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png?raw=true'
 dependencies:

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -13,7 +13,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 1.5.1
 appVersion: 3.1.0
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -11,7 +11,7 @@ keywords:
   - 'lidarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.5.1
+version: 1.6.0
 appVersion: 3.1.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png?raw=true'
 dependencies:

--- a/charts/profilarr/Chart.yaml
+++ b/charts/profilarr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'profilarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 2.0.0
+version: 2.1.0
 appVersion: 2.2.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/profilarr/icon.png?raw=true'
 maintainers:

--- a/charts/profilarr/Chart.yaml
+++ b/charts/profilarr/Chart.yaml
@@ -12,7 +12,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 2.0.0
 appVersion: 2.2.0
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/profilarr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/profilarr/icon.png?raw=true'
 maintainers:
   - name: 'media-servarr'
     email: 'git@jo.shw.al'

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -12,7 +12,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.26.0
 appVersion: 2.5.2
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'prowlarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.26.0
+version: 0.27.0
 appVersion: 2.5.2
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png?raw=true'
 dependencies:

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - 'radarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.8.0
+version: 1.9.0
 appVersion: 6.3.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png?raw=true'
 dependencies:

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -14,7 +14,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 1.8.0
 appVersion: 6.3.0
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - 'readarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: 0.4.19-nightly
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png?raw=true'
 deprecated: true

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -14,7 +14,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.15.1
 appVersion: 0.4.19-nightly
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png?raw=true'
 deprecated: true
 dependencies:
   - name: 'media-servarr-base'

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -8,7 +8,7 @@ keywords:
   - 'sabnzbd'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.3.1
+version: 1.4.0
 appVersion: 5.1.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png?raw=true'
 dependencies:

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -10,7 +10,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 1.3.1
 appVersion: 5.1.1
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -13,7 +13,7 @@ keywords:
   - 'sonarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.1
+version: 0.15.0
 appVersion: 4.0.19
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png?raw=true'
 dependencies:

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -15,7 +15,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.14.1
 appVersion: 4.0.19
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1

--- a/charts/tinymediamanager/Chart.yaml
+++ b/charts/tinymediamanager/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'tinymediamanager'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.3.2
+version: 1.4.0
 appVersion: 5.3.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png?raw=true'
 maintainers:

--- a/charts/tinymediamanager/Chart.yaml
+++ b/charts/tinymediamanager/Chart.yaml
@@ -12,7 +12,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 1.3.2
 appVersion: 5.3.1
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png?raw=true'
 maintainers:
   - name: 'media-servarr'
     email: 'git@jo.shw.al'

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'usenet'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: 4.1.3
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/transmission/icon.png?raw=true'
 dependencies:

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -12,7 +12,7 @@ kubeVersion: ">=1.24.0-0"
 type: 'application'
 version: 0.15.1
 appVersion: 4.1.3
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/transmission/icon.png'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/transmission/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.15.1


### PR DESCRIPTION
## Summary

Two commits — bundled so the new icon URL ships in the fresh chart releases:

1. **Icon URLs**: append `?raw=true` to every `icon:` in the repo. GitHub's `blob/…` URL returns HTML; adding `?raw=true` redirects to the raw image bytes, which artifacthub and other consumers need.
2. **Subchart minor bump**: patch/minor forward on each consumer chart so the icon URL fix ships as a new release.

`media-servarr-base` itself is **not** bumped, and its dependency pin in each consumer stays at `0.15.1` — the base is never published on its own, and the `file://` dep resolves against the local base regardless of the pin.

| Chart | old → new |
| --- | --- |
| bazarr | 0.15.1 → 0.16.0 |
| cleanuparr | 0.16.5 → 0.17.0 |
| flaresolverr | 0.15.1 → 0.16.0 |
| homarr | 0.50.0 → 0.51.0 |
| jellyfin | 0.14.1 → 0.15.0 |
| lidarr | 1.5.1 → 1.6.0 |
| profilarr | 2.0.0 → 2.1.0 |
| prowlarr | 0.26.0 → 0.27.0 |
| radarr | 1.8.0 → 1.9.0 |
| readarr | 0.15.1 → 0.16.0 |
| sabnzbd | 1.3.1 → 1.4.0 |
| sonarr | 0.14.1 → 0.15.0 |
| tinymediamanager | 1.3.2 → 1.4.0 |
| transmission | 0.15.1 → 0.16.0 |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Test plan

- [x] `curl -sIL '…icon.png?raw=true'` returns `200` with `content-type: image/png`.
- [x] `helm lint charts/*` unchanged vs `main` (base version + dep pins untouched).
- [ ] CI lint / schema-validation.