### PR TITLE
Bump media-servarr-base to 0.16.0 across all charts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: 'v2'
 name: 'media-servarr-base'
 description: 'Base chart for media-servarr charts'
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'bazarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: 1.6.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/cleanuparr/Chart.yaml
+++ b/charts/cleanuparr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'whisparr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.5
+version: 0.17.0
 appVersion: 2.10.5
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/cleanuparr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/flaresolverr/Chart.yaml
+++ b/charts/flaresolverr/Chart.yaml
@@ -9,12 +9,12 @@ keywords:
   - 'bypass'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: v3.5.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/flaresolverr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -7,12 +7,12 @@ keywords:
   - 'homarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.50.0
+version: 0.51.0
 appVersion: v1.75.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/homarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -15,12 +15,12 @@ keywords:
   - 'jellyfin'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.1
+version: 0.15.0
 appVersion: 10.11.11
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -11,12 +11,12 @@ keywords:
   - 'lidarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.5.1
+version: 1.6.0
 appVersion: 3.1.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/profilarr/Chart.yaml
+++ b/charts/profilarr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'profilarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 2.0.0
+version: 2.1.0
 appVersion: 2.2.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/profilarr/icon.png'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/profilarr'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'prowlarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.26.0
+version: 0.27.0
 appVersion: 2.5.2
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'radarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.8.0
+version: 1.9.0
 appVersion: 6.3.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -12,13 +12,13 @@ keywords:
   - 'readarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: 0.4.19-nightly
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png'
 deprecated: true
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -8,12 +8,12 @@ keywords:
   - 'sabnzbd'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.3.1
+version: 1.4.0
 appVersion: 5.1.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'sonarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.14.1
+version: 0.15.0
 appVersion: 4.0.19
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/tinymediamanager/Chart.yaml
+++ b/charts/tinymediamanager/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'tinymediamanager'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.3.2
+version: 1.4.0
 appVersion: 5.3.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/tinymediamanager'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'usenet'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: 4.1.3
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/transmission/icon.png'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.1
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'


### PR DESCRIPTION
## Summary

- Minor bump of `media-servarr-base` (0.15.1 → 0.16.0).
- Minor bump of every consumer chart plus its `media-servarr-base` dependency pin.
- Generated with `./scripts/update_base.sh minor`.

| Chart | old → new |
| --- | --- |
| media-servarr-base | 0.15.1 → 0.16.0 |
| bazarr | 0.15.1 → 0.16.0 |
| cleanuparr | 0.16.5 → 0.17.0 |
| flaresolverr | 0.15.1 → 0.16.0 |
| homarr | 0.50.0 → 0.51.0 |
| jellyfin | 0.14.1 → 0.15.0 |
| lidarr | 1.5.1 → 1.6.0 |
| profilarr | 2.0.0 → 2.1.0 |
| prowlarr | 0.26.0 → 0.27.0 |
| radarr | 1.8.0 → 1.9.0 |
| readarr | 0.15.1 → 0.16.0 |
| sabnzbd | 1.3.1 → 1.4.0 |
| sonarr | 0.14.1 → 0.15.0 |
| tinymediamanager | 1.3.2 → 1.4.0 |
| transmission | 0.15.1 → 0.16.0 |

## Test plan

- [x] `./scripts/update_base.sh minor` ran clean
- [x] Every consumer's `media-servarr-base` dep pin now points at `0.16.0`
- [x] `helm lint .` on base passes
- [ ] CI lint / schema-validation