### PR TITLE
Add Artifact Hub verified-publisher metadata

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -56,6 +56,7 @@ jobs:
           mkdir -p ./dist/charts
           mv .cr-release-packages/* ./dist/charts
           make pre-fetch && make index
+          cp artifacthub-repo.yml ./dist/charts/
           ls -R ./dist/
 
       - name: 'Upload Packaged Charts as Artifacts'
@@ -85,4 +86,4 @@ jobs:
           aws s3 cp ./dist/charts s3://media-servarr-helm-chart--mediaservarrhelmcharts3b-b6yezrsb3jje/charts --recursive
       - name: 'Invalidate CloudFront Distribution for index.yaml'
         run: |
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/charts/index.yaml"
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} --paths "/charts/index.yaml" "/charts/artifacthub-repo.yml"

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,4 @@
+repositoryID: 615d3686-55ab-4b0b-acc3-cbd9e99610f8
+owners:
+  - name: J J Walwyn
+    email: git@jo.shw.al


### PR DESCRIPTION
## Summary
- Adds `artifacthub-repo.yml` at repo root containing the Artifact Hub repository ID and owner, so Artifact Hub grants the verified-publisher badge.
- Wires the release workflow to ship the file alongside `index.yaml` on every publish and invalidate it in CloudFront so subsequent metadata edits (e.g. owner list) propagate.

## Test plan
- [x] Manually uploaded the file to `s3://.../charts/artifacthub-repo.yml` and invalidated CloudFront so verification can happen without waiting for a release run.
- [x] Confirm `https://media-servarr.shw.al/charts/artifacthub-repo.yml` returns the file.
- [ ] After the next chart release, confirm the workflow re-copies the file (unchanged) into `dist/charts/` and Artifact Hub still resolves it.
- [ ] Watch the Artifact Hub repo page for the "Verified Publisher" badge on the next scan (~30 min).