### PR TITLE
Bundle values.schema.json with each packaged chart

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,8 @@ jobs:
       - name: 'Prepare packaging'
         run: |
           #!/bin/sh
+          # Bundle values.schema.json into each chart before chart-releaser packages them
+          make sync-schema
           # Fetch current index.yaml
           CR_INDEX_DIR=.cr-index
           mkdir "$CR_INDEX_DIR"

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.tgz
 *.lock
 dist/
+
+# Per-chart values.schema.json is synced from the root schema at package/lint time.
+charts/*/values.schema.json

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: 'v2'
 name: 'media-servarr-base'
 description: 'Base chart for media-servarr charts'
 type: 'application'
-version: 0.15.2
+version: 0.16.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png?raw=true'

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: all lint package index clean
+.PHONY: all lint package index clean sync-schema
 
 CHARTS_DIR ?= charts/
 DIST := dist/charts
+SCHEMA := values.schema.json
 
 # Default value for CHILD_CHARTS is set to a shell command that finds all directories in CHARTS_DIR
 # This can be overridden by passing CHILD_CHARTS="chart1 chart2" to the make command
@@ -12,6 +13,12 @@ HELM_REPO ?= https://media-servarr.shw.al/charts
 
 # Default target
 build: package pre-fetch index
+
+# Copy the root values.schema.json into each subchart so tooling (helm lint,
+# helm package, artifact hub) can find it alongside the chart's values.yaml.
+sync-schema:
+	@echo "Syncing $(SCHEMA) into each chart..."
+	$(foreach chart,$(CHARTS), cp $(SCHEMA) "$(CHARTS_DIR)$(chart)/$(SCHEMA)";)
 
 # Lint the Helm charts
 lint:
@@ -24,7 +31,7 @@ test:
 	@$(foreach chart,$(CHILD_CHARTS),helm test $(chart) &&) echo "Helm tests completed."
 
 # Package the Helm charts
-package:
+package: sync-schema
 	@echo "Packaging charts..."
 	$(foreach chart,$(CHARTS), helm package "$(CHARTS_DIR)$(chart)" --dependency-update --destination $(DIST);)
 

--- a/charts/bazarr/Chart.yaml
+++ b/charts/bazarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'bazarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.1
+version: 0.17.0
 appVersion: 1.6.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/bazarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/cleanuparr/Chart.yaml
+++ b/charts/cleanuparr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'whisparr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.17.1
+version: 0.18.0
 appVersion: 2.10.5
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/cleanuparr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/flaresolverr/Chart.yaml
+++ b/charts/flaresolverr/Chart.yaml
@@ -9,12 +9,12 @@ keywords:
   - 'bypass'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.1
+version: 0.17.0
 appVersion: v3.5.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/flaresolverr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/homarr/Chart.yaml
+++ b/charts/homarr/Chart.yaml
@@ -7,12 +7,12 @@ keywords:
   - 'homarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.52.0
+version: 0.53.0
 appVersion: v1.76.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/homarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/jellyfin/Chart.yaml
+++ b/charts/jellyfin/Chart.yaml
@@ -15,12 +15,12 @@ keywords:
   - 'jellyfin'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: 10.11.11
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/jellyfin/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -11,12 +11,12 @@ keywords:
   - 'lidarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.6.1
+version: 1.7.0
 appVersion: 3.1.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/profilarr/Chart.yaml
+++ b/charts/profilarr/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'profilarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 2.1.1
+version: 2.2.0
 appVersion: 2.2.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/profilarr/icon.png?raw=true'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/profilarr'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."

--- a/charts/prowlarr/Chart.yaml
+++ b/charts/prowlarr/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'prowlarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.27.1
+version: 0.28.0
 appVersion: 2.5.2
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/prowlarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/radarr/Chart.yaml
+++ b/charts/radarr/Chart.yaml
@@ -12,12 +12,12 @@ keywords:
   - 'radarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.9.1
+version: 1.10.0
 appVersion: 6.3.0
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/readarr/Chart.yaml
+++ b/charts/readarr/Chart.yaml
@@ -12,13 +12,13 @@ keywords:
   - 'readarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.1
+version: 0.17.0
 appVersion: 0.4.19-nightly
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/readarr/icon.png?raw=true'
 deprecated: true
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sabnzbd/Chart.yaml
+++ b/charts/sabnzbd/Chart.yaml
@@ -8,12 +8,12 @@ keywords:
   - 'sabnzbd'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.4.1
+version: 1.5.0
 appVersion: 5.1.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sabnzbd/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/sonarr/Chart.yaml
+++ b/charts/sonarr/Chart.yaml
@@ -13,12 +13,12 @@ keywords:
   - 'sonarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.15.1
+version: 0.16.0
 appVersion: 4.0.19
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/sonarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'

--- a/charts/tinymediamanager/Chart.yaml
+++ b/charts/tinymediamanager/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - 'tinymediamanager'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.4.1
+version: 1.5.0
 appVersion: 5.3.1
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png?raw=true'
 maintainers:
@@ -23,5 +23,5 @@ sources:
   - 'https://github.com/drinkataco/media-servarr/tree/main/charts/tinymediamanager'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."

--- a/charts/transmission/Chart.yaml
+++ b/charts/transmission/Chart.yaml
@@ -10,12 +10,12 @@ keywords:
   - 'usenet'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 0.16.1
+version: 0.17.0
 appVersion: 4.1.3
 icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/transmission/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
-    version: 0.15.2
+    version: 0.16.0
     repository: "file://../.."
 maintainers:
   - name: 'media-servarr'


### PR DESCRIPTION
## Summary
- Adds a `sync-schema` Make target that copies the root `values.schema.json` into every `charts/*/` before packaging, so the schema ships inside each chart's `.tgz` next to `values.yaml`. Tools like `helm lint --strict`, `helm install --dry-run`, and Artifact Hub pick it up per-chart.
- Wires it into `make package` and into the `Prepare packaging` step of the release workflow (chart-releaser-action bypasses the Makefile).
- Gitignores `charts/*/values.schema.json` so the synced copies never get committed — root remains the single source of truth.

## Notes on schema completeness
Verified empirically that the current schema covers every value the base templates read and every key each subchart's `values.yaml` sets — `helm lint --strict` passes on all 14 real charts (bazarr, cleanuparr, flaresolverr, homarr, jellyfin, lidarr, profilarr, prowlarr, radarr, readarr, sabnzbd, sonarr, tinymediamanager, transmission) with the schema in place. No schema changes needed.

## Test plan
- [x] `make sync-schema` copies the schema into every chart dir.
- [x] `helm lint --strict` passes on every subchart with the schema applied.
- [x] `helm package charts/radarr` produces a `.tgz` containing both `radarr/values.schema.json` and (via dep) `radarr/charts/media-servarr-base/values.schema.json`.
- [x] `git status` doesn't see the synced copies (gitignore honoured).
- [ ] On merge, the next release run copies the schema into each chart before `chart-releaser-action` packages them, and downloaded `.tgz`s contain `values.schema.json`.