### PR TITLE
Fix chart icon URLs for lidarr and tinymediamanager

### DIFF
--- a/charts/lidarr/Chart.yaml
+++ b/charts/lidarr/Chart.yaml
@@ -11,9 +11,9 @@ keywords:
   - 'lidarr'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.8.0
+version: 1.8.1
 appVersion: 3.1.0
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/radarr/icon.png?raw=true'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/lidarr/icon.png?raw=true'
 dependencies:
   - name: 'media-servarr-base'
     version: 0.17.0

--- a/charts/tinymediamanager/Chart.yaml
+++ b/charts/tinymediamanager/Chart.yaml
@@ -10,9 +10,9 @@ keywords:
   - 'tinymediamanager'
 kubeVersion: ">=1.24.0-0"
 type: 'application'
-version: 1.6.0
+version: 1.6.1
 appVersion: 5.3.1
-icon: 'https://github.com/drinkataco/media-servarr/blob/main/icon.png?raw=true'
+icon: 'https://github.com/drinkataco/media-servarr/blob/main/charts/tinymediamanager/icon.png?raw=true'
 maintainers:
   - name: 'media-servarr'
     email: 'git@jo.shw.al'


### PR DESCRIPTION
## Summary
- **lidarr**: icon was pointing at `charts/radarr/icon.png` — swapped to `charts/lidarr/icon.png`. Patch bump to `1.8.1`.
- **tinymediamanager**: icon was pointing at the repo-root `icon.png` — swapped to `charts/tinymediamanager/icon.png`. Patch bump to `1.6.1`.

Both were rendering the wrong image on Artifact Hub / any consumer that fetched the chart metadata.

## Test plan
- [x] Chart.yaml diffs are surgical — only the icon URL and the patch version changed.
- [ ] Release workflow packages `lidarr-1.8.1.tgz` and `tinymediamanager-1.6.1.tgz` on merge.
- [ ] Artifact Hub picks up the corrected icons on next scan.